### PR TITLE
Improve responsive canvas and small screen support

### DIFF
--- a/challenge/challenge.html
+++ b/challenge/challenge.html
@@ -16,13 +16,21 @@
     <div class="header-title">Mode Challenge</div>
     <a class="header-home" href="../index.html" title="Accueil">🏠</a>
   </header>
-  <main class="container-game">
+  <main id="game-container" class="container-game">
     <div class="score-bar">
       <span>Score : <span id="score">0</span></span>
       <span>Défis : <span id="challenges">0</span></span>
       <span>Niveau : <span id="level">1</span></span>
     </div>
-    <canvas id="game-canvas" width="300" height="510"></canvas>
+    <div id="hold-container">
+      <p>Hold</p>
+      <canvas id="holdCanvas" width="80" height="80"></canvas>
+    </div>
+    <canvas id="gameCanvas" width="300" height="510"></canvas>
+    <div id="next-container">
+      <p>Next</p>
+      <canvas id="nextCanvas" width="80" height="80"></canvas>
+    </div>
     <div class="game-buttons">
       <button class="game-btn" id="pauseBtn">Pause</button>
       <button class="game-btn" id="settingsBtn">Options</button>

--- a/challenge/game_challenge.js
+++ b/challenge/game_challenge.js
@@ -1,9 +1,9 @@
 const canvas = document.getElementById("gameCanvas");
 const ctx = canvas.getContext("2d");
 const holdCanvas = document.getElementById("holdCanvas");
-const holdCtx = holdCanvas.getContext("2d");
+const holdCtx = holdCanvas ? holdCanvas.getContext("2d") : null;
 const nextCanvas = document.getElementById("nextCanvas");
-const nextCtx = nextCanvas.getContext("2d");
+const nextCtx = nextCanvas ? nextCanvas.getContext("2d") : null;
 
 const COLS = 10, ROWS = 20;
 let BLOCK_SIZE = 30;
@@ -79,14 +79,16 @@ function resizeCanvas() {
   canvas.style.height = canvas.height + "px";
 
   const miniSize = Math.max(Math.floor(BLOCK_SIZE * 4), 60);
-  [holdCanvas, nextCanvas].forEach(c => {
-    c.width = c.height = miniSize;
-    c.style.width = c.style.height = miniSize + "px";
-  });
+  if (holdCanvas && nextCanvas) {
+    [holdCanvas, nextCanvas].forEach(c => {
+      c.width = c.height = miniSize;
+      c.style.width = c.style.height = miniSize + "px";
+    });
+  }
 
   drawBoard();
-  drawMiniPiece(holdCtx, heldPiece, miniSize / 4);
-  drawMiniPiece(nextCtx, nextPiece, miniSize / 4);
+  if (holdCtx) drawMiniPiece(holdCtx, heldPiece, miniSize / 4);
+  if (nextCtx) drawMiniPiece(nextCtx, nextPiece, miniSize / 4);
 }
 window.addEventListener("resize", resizeCanvas);
 window.addEventListener("orientationchange", resizeCanvas);
@@ -184,8 +186,8 @@ function drawBoard() {
     );
   }
 
-  drawMiniPiece(nextCtx, nextPiece, null);
-  drawMiniPiece(holdCtx, heldPiece, null);
+  if (nextCtx) drawMiniPiece(nextCtx, nextPiece, null);
+  if (holdCtx) drawMiniPiece(holdCtx, heldPiece, null);
 }
 
 function drawMiniPiece(ctxRef, piece, size = null) {

--- a/classic/classic.html
+++ b/classic/classic.html
@@ -16,13 +16,21 @@
     <div class="header-title">Mode Classique</div>
     <a class="header-home" href="../index.html" title="Accueil">🏠</a>
   </header>
-  <main class="container-game">
+  <main id="game-container" class="container-game">
     <div class="score-bar">
       <span>Score : <span id="score">0</span></span>
       <span>Lignes : <span id="lines">0</span></span>
       <span>Niveau : <span id="level">1</span></span>
     </div>
-    <canvas id="game-canvas" width="300" height="510"></canvas>
+    <div id="hold-container">
+      <p>Hold</p>
+      <canvas id="holdCanvas" width="80" height="80"></canvas>
+    </div>
+    <canvas id="gameCanvas" width="300" height="510"></canvas>
+    <div id="next-container">
+      <p>Next</p>
+      <canvas id="nextCanvas" width="80" height="80"></canvas>
+    </div>
     <div class="game-buttons">
       <button class="game-btn" id="pauseBtn">Pause</button>
       <button class="game-btn" id="settingsBtn">Options</button>

--- a/classic/game_classic.js
+++ b/classic/game_classic.js
@@ -2,17 +2,20 @@
 const canvas     = document.getElementById("gameCanvas");
 const ctx        = canvas.getContext("2d");
 const holdCanvas = document.getElementById("holdCanvas");
-const holdCtx    = holdCanvas.getContext("2d");
+const holdCtx    = holdCanvas ? holdCanvas.getContext("2d") : null;
 const nextCanvas = document.getElementById("nextCanvas");
-const nextCtx    = nextCanvas.getContext("2d");
+const nextCtx    = nextCanvas ? nextCanvas.getContext("2d") : null;
 
 let BLOCK_SIZE = 30;
 const COLS = 10, ROWS = 20;
 
 // Responsive canvas & side panels (next/hold)
 function resizeAllCanvas() {
-  const maxW = Math.min(window.innerWidth * 0.95, 420);
-  BLOCK_SIZE = Math.floor(maxW / COLS);
+  const availableWidth = Math.min(window.innerWidth * 0.97, 420);
+  const availableHeight = Math.max(window.innerHeight * 0.73, 300);
+  const blockW = Math.floor(availableWidth / COLS);
+  const blockH = Math.floor(availableHeight / ROWS);
+  BLOCK_SIZE = Math.min(blockW, blockH, 32);
 
   canvas.width = COLS * BLOCK_SIZE;
   canvas.height = ROWS * BLOCK_SIZE;
@@ -20,14 +23,16 @@ function resizeAllCanvas() {
   canvas.style.height = canvas.height + "px";
 
   const miniSize = Math.max(Math.floor(BLOCK_SIZE * 4), 60);
-  [holdCanvas, nextCanvas].forEach(c => {
-    c.width = c.height = miniSize;
-    c.style.width = c.style.height = miniSize + "px";
-  });
+  if (holdCanvas && nextCanvas) {
+    [holdCanvas, nextCanvas].forEach(c => {
+      c.width = c.height = miniSize;
+      c.style.width = c.style.height = miniSize + "px";
+    });
+  }
 
   drawBoard();
-  drawMiniPiece(holdCtx, heldPiece);
-  drawMiniPiece(nextCtx, nextPiece);
+  if (holdCtx) drawMiniPiece(holdCtx, heldPiece, miniSize / 4);
+  if (nextCtx) drawMiniPiece(nextCtx, nextPiece, miniSize / 4);
 }
 
 window.addEventListener("resize", resizeAllCanvas);
@@ -139,7 +144,7 @@ function reset() {
   currentPiece = nextPiece || newPiece();
   nextPiece    = newPiece();
   holdUsed     = false;
-  drawMiniPiece(nextCtx, nextPiece);
+  if (nextCtx) drawMiniPiece(nextCtx, nextPiece);
 }
 
 function drawBlockCustom(ctx, x, y, letter, size = BLOCK_SIZE, alpha = 1) {
@@ -278,7 +283,7 @@ function holdPiece() {
     [heldPiece, currentPiece] = [{ ...currentPiece }, { ...heldPiece }];
   }
   holdUsed = true;
-  drawMiniPiece(holdCtx, heldPiece);
+  if (holdCtx) drawMiniPiece(holdCtx, heldPiece);
 }
 
 // --- Contrôles clavier & tactile ---

--- a/infini/game_infini.js
+++ b/infini/game_infini.js
@@ -1,9 +1,9 @@
 const canvas = document.getElementById("gameCanvas");
 const ctx = canvas.getContext("2d");
 const holdCanvas = document.getElementById("holdCanvas");
-const holdCtx = holdCanvas.getContext("2d");
+const holdCtx = holdCanvas ? holdCanvas.getContext("2d") : null;
 const nextCanvas = document.getElementById("nextCanvas");
-const nextCtx = nextCanvas.getContext("2d");
+const nextCtx = nextCanvas ? nextCanvas.getContext("2d") : null;
 
 const COLS = 10, ROWS = 20;
 let BLOCK_SIZE = 30;
@@ -22,14 +22,16 @@ function resizeCanvas() {
   canvas.style.height = canvas.height + "px";
 
   const miniSize = Math.max(Math.floor(BLOCK_SIZE * 4), 60);
-  [holdCanvas, nextCanvas].forEach(c => {
-    c.width = c.height = miniSize;
-    c.style.width = c.style.height = miniSize + "px";
-  });
+  if (holdCanvas && nextCanvas) {
+    [holdCanvas, nextCanvas].forEach(c => {
+      c.width = c.height = miniSize;
+      c.style.width = c.style.height = miniSize + "px";
+    });
+  }
 
   drawBoard();
-  drawMiniPiece(holdCtx, heldPiece, miniSize / 4);
-  drawMiniPiece(nextCtx, nextPiece, miniSize / 4);
+  if (holdCtx) drawMiniPiece(holdCtx, heldPiece, miniSize / 4);
+  if (nextCtx) drawMiniPiece(nextCtx, nextPiece, miniSize / 4);
 }
 window.addEventListener("resize", resizeCanvas);
 window.addEventListener("orientationchange", resizeCanvas);
@@ -171,7 +173,7 @@ function holdPiece() {
     [heldPiece, currentPiece] = [{ ...currentPiece }, { ...heldPiece }];
   }
   holdUsed = true;
-  drawMiniPiece(holdCtx, heldPiece);
+  if (holdCtx) drawMiniPiece(holdCtx, heldPiece);
 }
 
 function drawBlockCustom(ctx, x, y, letter, size = BLOCK_SIZE, alpha = 1) {
@@ -283,7 +285,7 @@ function reset() {
   currentPiece = nextPiece || newPiece();
   nextPiece = newPiece();
   holdUsed = false;
-  drawMiniPiece(nextCtx, nextPiece);
+  if (nextCtx) drawMiniPiece(nextCtx, nextPiece);
 }
 
 // --- Contrôles clavier ---

--- a/infini/infini.html
+++ b/infini/infini.html
@@ -16,13 +16,21 @@
     <div class="header-title">Mode Infini</div>
     <a class="header-home" href="../index.html" title="Accueil">🏠</a>
   </header>
-  <main class="container-game">
+  <main id="game-container" class="container-game">
     <div class="score-bar">
       <span>Score : <span id="score">0</span></span>
       <span>Lignes : <span id="lines">0</span></span>
       <span>Temps : <span id="time">0:00</span></span>
     </div>
-    <canvas id="game-canvas" width="300" height="510"></canvas>
+    <div id="hold-container">
+      <p>Hold</p>
+      <canvas id="holdCanvas" width="80" height="80"></canvas>
+    </div>
+    <canvas id="gameCanvas" width="300" height="510"></canvas>
+    <div id="next-container">
+      <p>Next</p>
+      <canvas id="nextCanvas" width="80" height="80"></canvas>
+    </div>
     <div class="game-buttons">
       <button class="game-btn" id="pauseBtn">Pause</button>
       <button class="game-btn" id="settingsBtn">Options</button>

--- a/style/main.css
+++ b/style/main.css
@@ -169,7 +169,7 @@ h1 {
   color: #ffe04a;
   text-shadow: 1px 1px 4px #201;
 }
-#game-canvas {
+#gameCanvas {
   display: block;
   margin: 0 auto;
   border-radius: 22px;
@@ -220,7 +220,7 @@ h1 {
   .header-title { font-size: 1.2rem; }
   .score-bar { font-size: 1.01rem; gap: 0.5em; }
   .game-btn { font-size: 1.01rem; padding: 0.5em 0.8em; min-width: 72px;}
-  #game-canvas { border-radius: 16px; }
+  #gameCanvas { border-radius: 16px; }
   .container-game { margin-top: 0.8vw; }
 }
 
@@ -229,10 +229,17 @@ h1 {
   .logo-main { width: 49px; }
   .header-title { font-size: 1rem; }
   .score-bar { font-size: 0.98rem; }
-  #game-canvas { max-width: 99vw; }
+  #gameCanvas { max-width: 99vw; }
   .container-game { margin-top: 0.2vw; }
   .menu-jeux { gap: 0.5rem; }
   .menu-jeux a { padding: 0.7em 0.4em; font-size: 0.98rem; min-height: 39px;}
   h1 { font-size: 1.25rem; }
   body { padding: 0 0 6vw 0; }
+}
+
+/* ======= Tiny Mobile (max 360px) ======= */
+@media (max-width: 360px) {
+  .menu-jeux a { font-size: 0.92rem; }
+  .game-btn { font-size: 0.9rem; padding: 0.45em 0.7em; }
+  .score-bar { font-size: 0.9rem; }
 }


### PR DESCRIPTION
## Summary
- ensure game canvas IDs match between HTML, CSS and JS
- add hold and next piece panels for all game modes
- tweak resize logic to adapt to viewport height as well
- guard mini canvas operations when panels are missing
- add tiny mobile styles for very small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fa44c6de48321ab02e4c9e99a395d