### PR TITLE
Add .gitignore for build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Node dependencies
+node_modules/
+
+# Build outputs
+classic/bundle.js
+infini/bundle.js
+challenge/bundle.js
+
+# Misc
+.DS_Store
+npm-debug.log*


### PR DESCRIPTION
## Summary
- ignore `node_modules/` and generated `bundle.js`
- exclude typical misc files like `.DS_Store` and npm debug logs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fafaa47708321bacb6a864053dce7