### PR TITLE
Deduplicate whenReady helper

### DIFF
--- a/challenge/game_challenge.js
+++ b/challenge/game_challenge.js
@@ -320,15 +320,9 @@ document.addEventListener("keydown", (e) => {
 });
 
 // --- Contrôles boutons physiques (optionnel)
-function whenReady(fn) {
-  if (window.cordova || window.Capacitor) {
-    document.addEventListener('deviceready', fn, false);
-  } else if (document.readyState !== 'loading') {
-    fn();
-  } else {
-    document.addEventListener('DOMContentLoaded', fn);
-  }
-}
+const { whenReady } = typeof module !== 'undefined' && module.exports
+  ? require('../scripts/utils')
+  : window;
 
 whenReady(() => {
   const btnLeft   = document.querySelector("button[data-action='left']");

--- a/challenge/intro.js
+++ b/challenge/intro.js
@@ -1,12 +1,6 @@
-function whenReady(fn) {
-  if (window.cordova || window.Capacitor) {
-    document.addEventListener('deviceready', fn, false);
-  } else if (document.readyState !== 'loading') {
-    fn();
-  } else {
-    document.addEventListener('DOMContentLoaded', fn);
-  }
-}
+const { whenReady } = typeof module !== 'undefined' && module.exports
+  ? require('../scripts/utils')
+  : window;
 
 whenReady(function () {
   alert("Bienvenue dans V-Blocks ! Le but du jeu est simple : remplir des lignes avec les pièces qui tombent. Bon jeu !");

--- a/classic/controls.js
+++ b/classic/controls.js
@@ -1,12 +1,6 @@
-function whenReady(fn) {
-  if (window.cordova || window.Capacitor) {
-    document.addEventListener('deviceready', fn, false);
-  } else if (document.readyState !== 'loading') {
-    fn();
-  } else {
-    document.addEventListener('DOMContentLoaded', fn);
-  }
-}
+const { whenReady } = typeof module !== 'undefined' && module.exports
+  ? require('../scripts/utils')
+  : window;
 
 whenReady(() => {
   // Contrôles directionnels (boutons physiques)

--- a/infini/controls.js
+++ b/infini/controls.js
@@ -1,12 +1,6 @@
-function whenReady(fn) {
-  if (window.cordova || window.Capacitor) {
-    document.addEventListener('deviceready', fn, false);
-  } else if (document.readyState !== 'loading') {
-    fn();
-  } else {
-    document.addEventListener('DOMContentLoaded', fn);
-  }
-}
+const { whenReady } = typeof module !== 'undefined' && module.exports
+  ? require('../scripts/utils')
+  : window;
 
 whenReady(() => {
   // Contrôles directionnels (boutons physiques)

--- a/scripts/pause.js
+++ b/scripts/pause.js
@@ -1,12 +1,6 @@
-function whenReady(fn) {
-  if (window.cordova || window.Capacitor) {
-    document.addEventListener('deviceready', fn, false);
-  } else if (document.readyState !== 'loading') {
-    fn();
-  } else {
-    document.addEventListener('DOMContentLoaded', fn);
-  }
-}
+const { whenReady } = typeof module !== 'undefined' && module.exports
+  ? require('./utils')
+  : window;
 
 whenReady(function() {
   const settingsButton = document.getElementById("settings-button");

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -1,12 +1,6 @@
-function whenReady(fn) {
-  if (window.cordova || window.Capacitor) {
-    document.addEventListener('deviceready', fn, false);
-  } else if (document.readyState !== 'loading') {
-    fn();
-  } else {
-    document.addEventListener('DOMContentLoaded', fn);
-  }
-}
+const { whenReady } = typeof module !== 'undefined' && module.exports
+  ? require('./utils')
+  : window;
 
 whenReady(function() {
   const settingsButton = document.getElementById("settings-button");

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,15 @@
+function whenReady(fn) {
+  if (window.cordova || window.Capacitor) {
+    document.addEventListener('deviceready', fn, false);
+  } else if (document.readyState !== 'loading') {
+    fn();
+  } else {
+    document.addEventListener('DOMContentLoaded', fn);
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { whenReady };
+} else {
+  window.whenReady = whenReady;
+}


### PR DESCRIPTION
## Summary
- add shared `whenReady` helper in `scripts/utils.js`
- use the helper in game controls and settings scripts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fafad8304832181140e5dc3fd84e1