### PR TITLE
Add reward data attributes to boutique cartouches and restrict timed interstitials to game screens

### DIFF
--- a/boutique.html
+++ b/boutique.html
@@ -334,13 +334,23 @@ function renderCartouche(c, extraClass = ''){
   ].filter(Boolean).join(' ');
 
   if (isReward) {
+    const rewardAction =
+      c.key === "boutique.cartouche.pub1jeton"
+        ? 'data-action="reward-jeton"'
+        : c.key === "boutique.cartouche.pub300points"
+          ? 'data-action="reward-vcoins"'
+          : '';
+
     return `
-      <div class="special-cartouche ${c.color} ${classes}" ${c.productId ? `data-product-id="${c.productId}"` : ""}>
+      <div class="special-cartouche ${c.color} ${classes}"
+           ${c.productId ? `data-product-id="${c.productId}"` : ""}
+           data-reward-key="${c.key}"
+           ${rewardAction}>
         <div class="reward-top">
           <span class="theme-ico">${c.icon}</span>
           <span class="reward-amount">+ ${c.amount}</span>
         </div>
-        <span class="theme-label" data-i18n="end.reward.vcoins">${t('end.reward.vcoins')}</span>
+        <span class="theme-label" data-i18n="${c.key}">${t(c.key)}</span>
       </div>
     `;
   }
@@ -429,25 +439,40 @@ async function renderThemes(){
 /* ---------- pubs récompensées ---------- */
 function setupPubCartouches(){
   document.querySelectorAll('#achats-list .special-cartouche').forEach(cartouche=>{
-    const label = cartouche.querySelector('.theme-label'); if(!label) return;
-    const key = label.dataset.i18n;
+    const rewardKey =
+      cartouche.dataset.rewardKey ||
+      cartouche.querySelector('.theme-label')?.dataset?.i18n ||
+      '';
 
-    if (key==='boutique.cartouche.pub1jeton'){
-      cartouche.style.cursor='pointer';
+    if (rewardKey === 'boutique.cartouche.pub1jeton'){
+      cartouche.style.cursor = 'pointer';
       cartouche.onclick = async ()=>{
-        cartouche.onclick=null;
-        try{ await window.showRewardBoutique?.(); await renderThemes(); }
-        catch(e){ alert("Erreur : " + (e?.message||e)); }
-        finally{ setupPubCartouches(); }
+        cartouche.onclick = null;
+        try {
+          const ok = await window.showRewardBoutique?.();
+          if (!ok) throw new Error('Récompense jeton non validée');
+          await renderThemes();
+        } catch(e){
+          alert("Erreur : " + (e?.message || e));
+        } finally {
+          setupPubCartouches();
+        }
       };
     }
-    if (key==='boutique.cartouche.pub300points'){
-      cartouche.style.cursor='pointer';
+
+    if (rewardKey === 'boutique.cartouche.pub300points'){
+      cartouche.style.cursor = 'pointer';
       cartouche.onclick = async ()=>{
-        cartouche.onclick=null;
-        try{ await window.showRewardVcoins?.(); await renderThemes(); }
-        catch(e){ alert("Erreur : " + (e?.message||e)); }
-        finally{ setupPubCartouches(); }
+        cartouche.onclick = null;
+        try {
+          const ok = await window.showRewardVcoins?.();
+          if (!ok) throw new Error('Récompense VCoins non validée');
+          await renderThemes();
+        } catch(e){
+          alert("Erreur : " + (e?.message || e));
+        } finally {
+          setupPubCartouches();
+        }
       };
     }
   });

--- a/js/pub.js
+++ b/js/pub.js
@@ -24,7 +24,7 @@
   var INTER_COOLDOWN_MS = 3 * 60 * 1000;       // minimum 3 minutes entre deux pubs
 
   // --- Timer auto hors jeu / index ---
-  var INTER_ECRAN_VISIBLE_MS = 4 * 60 * 1000;  // pub auto toutes les 4 minutes de temps d'écran visible
+  var INTER_ECRAN_VISIBLE_MS = 3 * 60 * 1000;  // pub auto toutes les 3 minutes de temps d'écran visible
   var INTER_ECRAN_TICK_MS = 15000;             // vérification légère toutes les 15s
 
   // --- Récompenses par défaut (affichage/UI) ---
@@ -843,6 +843,22 @@ function informCapBlocked() {
     );
   }
 
+  function isRealGameScreen() {
+    try {
+      var path = (location.pathname || '').toLowerCase();
+      return (
+        path.endsWith('/classic.html') ||
+        path.endsWith('/infini.html') ||
+        path.endsWith('/duel.html') ||
+        path.endsWith('/concours.html') ||
+        path.endsWith('/ads.html') ||
+        path.endsWith('/game.html')
+      );
+    } catch (_) {
+      return false;
+    }
+  }
+
   function getInterstitialScreenVisibleMs() {
     var total = interScreenVisibleMs;
     if (!document.hidden && interScreenLastResumeTs > 0) {
@@ -882,6 +898,7 @@ function informCapBlocked() {
 
   async function maybeShowInterstitialByScreenTime() {
     if (document.hidden) return false;
+    if (!isRealGameScreen()) return false;
     if (hasBlockingUiForAutoInterstitial()) return false;
     if (getInterstitialScreenVisibleMs() < INTER_ECRAN_VISIBLE_MS) return false;
     if (!canShowInterstitialNow()) return false;


### PR DESCRIPTION
### Motivation
- Make reward cartouches in the boutique more robust and machine-readable by adding explicit data attributes and clearer action markers. 
- Ensure rewarded ad flows validate their result before refreshing UI and provide explicit error messages when validation fails.
- Prevent automatic interstitials from being shown outside real game screens and reduce the auto-show interval slightly to improve UX.

### Description
- In `boutique.html` updated `renderCartouche(...)` for reward entries to add `data-reward-key`, conditional `data-action` attributes (`reward-jeton` / `reward-vcoins`), and use the dynamic i18n key via `data-i18n="${c.key}"` and `t(c.key)`. 
- Replaced `setupPubCartouches()` in `boutique.html` to resolve the reward key from `data-reward-key` (with fallback to the label i18n), call the appropriate reward function, validate the returned `ok` result, show an error on failure, and re-initialize handlers afterwards. 
- In `js/pub.js` changed `INTER_ECRAN_VISIBLE_MS` from 4 minutes to 3 minutes to adjust auto-interstitial timing. 
- Added `isRealGameScreen()` in `js/pub.js` and updated `maybeShowInterstitialByScreenTime()` to require `isRealGameScreen()` before attempting to show timed interstitials. 

### Testing
- Ran `git diff --check` to ensure no whitespace or patch errors and it returned clean. 
- Ran `git status --short` and reviewed diffs to confirm the intended replacements in `boutique.html` and `js/pub.js` were applied. 
- Manual review of file diffs was performed to verify the implemented logic and error handling for rewarded flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95333909c83218feedec7f814ec90)