### PR TITLE
Add Android test/prod ad ID switch, remove duplicate reward bindings, and fix interstitial clock

### DIFF
--- a/js/boutique.js
+++ b/js/boutique.js
@@ -134,30 +134,6 @@
       }, { passive: false });
     });
 
-    // Pubs récompensées (si présentes en HTML)
-    const oneJeton = document.querySelector('[data-action="reward-jeton"]');
-    if (oneJeton) oneJeton.addEventListener('click', async (e) => {
-      e.preventDefault();
-      try {
-        if (typeof window.showRewardBoutique === 'function') await window.showRewardBoutique();
-      } catch (err) {
-        alert(t('pub.err','Publicité indisponible pour le moment.'));
-      } finally {
-        updateBalancesHeader();
-      }
-    });
-
-    const threeHundred = document.querySelector('[data-action="reward-vcoins"]');
-    if (threeHundred) threeHundred.addEventListener('click', async (e) => {
-      e.preventDefault();
-      try {
-        if (typeof window.showRewardVcoins === 'function') await window.showRewardVcoins();
-      } catch (err) {
-        alert(t('pub.err','Publicité indisponible pour le moment.'));
-      } finally {
-        updateBalancesHeader();
-      }
-    });
   }
 
   // ---------- Bootstrap (aucun rendu) ----------

--- a/js/pub.js
+++ b/js/pub.js
@@ -10,13 +10,25 @@
   var App = (Capacitor.App) ? Capacitor.App
           : ((Capacitor.Plugins && Capacitor.Plugins.App) ? Capacitor.Plugins.App : null);
 
-  // ------- STRICT PROD -------
-  var __DEV_ADS__ = false;      // true pour tests locaux
-  var SHOW_DIAG_PANEL = false;  // overlay debug (laisse false en prod)
+  // ------- TEST / PROD -------
+  var USE_TEST_AD_IDS = true;   // true = IDs test Android Studio / false = tes vraies IDs
+  var __DEV_ADS__ = USE_TEST_AD_IDS;
+  var SHOW_DIAG_PANEL = false;
 
-  // --- Tes Ad Units réelles ---
-  var AD_UNIT_ID_INTERSTITIEL = 'ca-app-pub-6837328794080297/9890831605';
-  var AD_UNIT_ID_REWARDED     = 'ca-app-pub-6837328794080297/3006407791';
+  // --- IDs AdMob Android ---
+  var TEST_AD_UNIT_ID_INTERSTITIEL = 'ca-app-pub-3940256099942544/1033173712';
+  var TEST_AD_UNIT_ID_REWARDED     = 'ca-app-pub-3940256099942544/5224354917';
+
+  var PROD_AD_UNIT_ID_INTERSTITIEL = 'ca-app-pub-6837328794080297/9890831605';
+  var PROD_AD_UNIT_ID_REWARDED     = 'ca-app-pub-6837328794080297/3006407791';
+
+  var AD_UNIT_ID_INTERSTITIEL = USE_TEST_AD_IDS
+    ? TEST_AD_UNIT_ID_INTERSTITIEL
+    : PROD_AD_UNIT_ID_INTERSTITIEL;
+
+  var AD_UNIT_ID_REWARDED = USE_TEST_AD_IDS
+    ? TEST_AD_UNIT_ID_REWARDED
+    : PROD_AD_UNIT_ID_REWARDED;
 
   // --- Réglages interstitiels ---
   var INTERSTITIEL_APRES_X_ACTIONS = 2;        // pub au début de la 3e action réelle
@@ -358,13 +370,11 @@ function informCapBlocked() {
   }
 
   document.addEventListener('visibilitychange', function(){
-    if (document.hidden) {
-      stopInterstitialScreenClock();
-      return;
-    }
+    syncInterstitialClockForCurrentScreen();
 
-    startInterstitialScreenClock();
-    setTimeout(function(){ maybeShowInterstitialByScreenTime().catch(function(){}); }, 800);
+    if (!document.hidden) {
+      setTimeout(function(){ maybeShowInterstitialByScreenTime().catch(function(){}); }, 800);
+    }
 
     if (!isRewardShowing) postAdCleanup();
   });
@@ -374,7 +384,7 @@ function informCapBlocked() {
   });
 
   window.addEventListener('pageshow', function(){
-    startInterstitialScreenClock();
+    syncInterstitialClockForCurrentScreen();
     setTimeout(function(){ maybeShowInterstitialByScreenTime().catch(function(){}); }, 800);
   });
 
@@ -384,7 +394,7 @@ function informCapBlocked() {
         stopInterstitialScreenClock();
       });
       App.addListener('resume', function(){
-        startInterstitialScreenClock();
+        syncInterstitialClockForCurrentScreen();
         setTimeout(function(){ maybeShowInterstitialByScreenTime().catch(function(){}); }, 800);
       });
     }
@@ -859,6 +869,18 @@ function informCapBlocked() {
     }
   }
 
+  function syncInterstitialClockForCurrentScreen() {
+    if (document.hidden) {
+      stopInterstitialScreenClock();
+      return;
+    }
+    if (isRealGameScreen()) {
+      startInterstitialScreenClock();
+    } else {
+      stopInterstitialScreenClock();
+    }
+  }
+
   function getInterstitialScreenVisibleMs() {
     var total = interScreenVisibleMs;
     if (!document.hidden && interScreenLastResumeTs > 0) {
@@ -868,6 +890,8 @@ function informCapBlocked() {
   }
 
   function startInterstitialScreenClock() {
+    if (!isRealGameScreen()) return;
+
     if (!document.hidden && interScreenLastResumeTs <= 0) {
       interScreenLastResumeTs = Date.now();
       persistInterstitialScreenClock();
@@ -1088,7 +1112,7 @@ function informCapBlocked() {
     window.__ads_waiting_choice = !!isOpen;
   };
 
-  startInterstitialScreenClock();
+  syncInterstitialClockForCurrentScreen();
   setTimeout(function(){ maybeShowInterstitialByScreenTime().catch(function(){}); }, 1200);
 
 })();


### PR DESCRIPTION
### Motivation
- Provide a simple global switch to run Android builds with Google test AdMob IDs during development and switch to production IDs for release.
- Prevent duplicate rewarded-ad click bindings so the HTML-driven reward wiring remains the single source of truth.
- Ensure the 3-minute interstitial screen-time clock only runs while on real game screens and stays synchronized on visibility/app lifecycle events.

### Description
- Replaced the top-of-file ad configuration in `js/pub.js` with a `USE_TEST_AD_IDS` boolean and added test and prod AdMob IDs plus computed `AD_UNIT_ID_INTERSTITIEL` and `AD_UNIT_ID_REWARDED` selection logic.
- Removed the rewarded ad click handlers from `setupBoutiqueActions()` in `js/boutique.js` so rewarded binding is not duplicated (HTML still drives the real wiring).
- Added `syncInterstitialClockForCurrentScreen()` to `js/pub.js`, modified `startInterstitialScreenClock()` to only start on real game screens, and updated `visibilitychange`, `pageshow`, and app `resume` handlers to use the new sync helper and adjusted the bootstrap call accordingly.
- Modified initialization so the interstitial clock is synchronized at startup instead of unconditionally started.

### Testing
- Ran `node --check js/pub.js` and it completed successfully.
- Ran `node --check js/boutique.js` and it completed successfully.
- Verified both `js/pub.js` and `js/boutique.js` were updated as intended (static checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da283b94188321a7da0b5e54054a8f)