### PR TITLE
Répétition horizontale tactile : départ immédiat et intervalle 120ms

### DIFF
--- a/ads.html
+++ b/ads.html
@@ -1862,34 +1862,32 @@ if (score > highscoreCloud) {
     }
 
     // ===== Repeat horizontal tactile =====
-    let horizontalRepeatKickoff = null;
     let horizontalRepeatInterval = null;
-
-    const INITIAL_REPEAT_DELAY = 180;
-    const REPEAT_INTERVAL = 60;
+    let horizontalRepeatDirection = 0;
 
     function startHorizontalRepeat(direction) {
-      if (paused || gameOver) return;
+      if (paused || gameOver || window.__ads_active) return;
       if (direction !== -1 && direction !== 1) return;
 
-      stopHorizontalRepeat();
+      if (horizontalRepeatDirection === direction && horizontalRepeatInterval) return;
 
-      horizontalRepeatKickoff = setTimeout(() => {
-        horizontalRepeatKickoff = null;
-        horizontalRepeatInterval = setInterval(() => {
-          if (!paused && !gameOver && !window.__ads_active) {
-            move(direction);
-            safeRedraw();
-          }
-        }, REPEAT_INTERVAL);
-      }, INITIAL_REPEAT_DELAY);
+      stopHorizontalRepeat();
+      horizontalRepeatDirection = direction;
+
+      move(direction);
+      safeRedraw();
+
+      horizontalRepeatInterval = setInterval(() => {
+        if (!paused && !gameOver && !window.__ads_active) {
+          move(direction);
+          safeRedraw();
+        }
+      }, 120);
     }
 
     function stopHorizontalRepeat() {
-      if (horizontalRepeatKickoff) {
-        clearTimeout(horizontalRepeatKickoff);
-        horizontalRepeatKickoff = null;
-      }
+      horizontalRepeatDirection = 0;
+
       if (horizontalRepeatInterval) {
         clearInterval(horizontalRepeatInterval);
         horizontalRepeatInterval = null;
@@ -2042,16 +2040,12 @@ if (score > highscoreCloud) {
 
       if (gestureMode === 'horizontal') {
         if (movedX > HORIZ_THRESHOLD) {
-          move(1);
-          startX = t.clientX;
           startHorizontalRepeat(1);
-        } else if (movedX < -HORIZ_THRESHOLD) {
-          move(-1);
           startX = t.clientX;
+        } else if (movedX < -HORIZ_THRESHOLD) {
           startHorizontalRepeat(-1);
-        }
-
-        if (Math.abs(movedX) <= HORIZ_THRESHOLD) {
+          startX = t.clientX;
+        } else {
           stopHorizontalRepeat();
         }
 

--- a/js/game.js
+++ b/js/game.js
@@ -2025,34 +2025,32 @@ if (score > highscoreCloud) {
     }
 
     // ===== Repeat horizontal tactile =====
-    let horizontalRepeatKickoff = null;
     let horizontalRepeatInterval = null;
-
-    const INITIAL_REPEAT_DELAY = 180;
-    const REPEAT_INTERVAL = 60;
+    let horizontalRepeatDirection = 0;
 
     function startHorizontalRepeat(direction) {
-      if (paused || gameOver) return;
+      if (paused || gameOver || window.__ads_active) return;
       if (direction !== -1 && direction !== 1) return;
 
-      stopHorizontalRepeat();
+      if (horizontalRepeatDirection === direction && horizontalRepeatInterval) return;
 
-      horizontalRepeatKickoff = setTimeout(() => {
-        horizontalRepeatKickoff = null;
-        horizontalRepeatInterval = setInterval(() => {
-          if (!paused && !gameOver && !window.__ads_active) {
-            move(direction);
-            safeRedraw();
-          }
-        }, REPEAT_INTERVAL);
-      }, INITIAL_REPEAT_DELAY);
+      stopHorizontalRepeat();
+      horizontalRepeatDirection = direction;
+
+      move(direction);
+      safeRedraw();
+
+      horizontalRepeatInterval = setInterval(() => {
+        if (!paused && !gameOver && !window.__ads_active) {
+          move(direction);
+          safeRedraw();
+        }
+      }, 120);
     }
 
     function stopHorizontalRepeat() {
-      if (horizontalRepeatKickoff) {
-        clearTimeout(horizontalRepeatKickoff);
-        horizontalRepeatKickoff = null;
-      }
+      horizontalRepeatDirection = 0;
+
       if (horizontalRepeatInterval) {
         clearInterval(horizontalRepeatInterval);
         horizontalRepeatInterval = null;
@@ -2205,16 +2203,12 @@ if (score > highscoreCloud) {
 
       if (gestureMode === 'horizontal') {
         if (movedX > HORIZ_THRESHOLD) {
-          move(1);
-          startX = t.clientX;
           startHorizontalRepeat(1);
-        } else if (movedX < -HORIZ_THRESHOLD) {
-          move(-1);
           startX = t.clientX;
+        } else if (movedX < -HORIZ_THRESHOLD) {
           startHorizontalRepeat(-1);
-        }
-
-        if (Math.abs(movedX) <= HORIZ_THRESHOLD) {
+          startX = t.clientX;
+        } else {
           stopHorizontalRepeat();
         }
 


### PR DESCRIPTION
### Motivation
- Simplifier et aligner le comportement tactile latéral pour que le déplacement horizontal parte immédiatement et répète plus vite, sans délai initial.
- Éviter les timers de kickoff redondants et gérer proprement le sens courant pour éviter la duplication d'intervalles.
- Appliquer le même changement dans la version embarquée (`ads.html`) pour garder la logique riche et la version public cohérentes.

### Description
- Remplace la logique de `// ===== Repeat horizontal tactile =====` dans `js/game.js` et `ads.html` pour supprimer le `INITIAL_REPEAT_DELAY` et déclencher un déplacement immédiat suivi d'une répétition toutes les `120` ms.
- Remplace la variable `horizontalRepeatKickoff` par un suivi du sens via `horizontalRepeatDirection` et empêche la recréation d'un intervalle si le sens est déjà actif.
- Ajoute la garde `if (paused || gameOver || window.__ads_active) return;` dans `startHorizontalRepeat` pour éviter de démarrer la répétition dans des états non valides.
- Simplifie le bloc `gestureMode === 'horizontal'` dans l'écouteur `touchmove` pour déléguer les déplacements à `startHorizontalRepeat` et appeler `stopHorizontalRepeat()` quand on sort du seuil.

### Testing
- Local recherche des occurrences modifiées avec `rg -n "Repeat horizontal tactile|horizontalRepeatKickoff|gestureMode === 'horizontal'" -S` pour vérifier les fichiers ciblés, et la commande a retourné les fichiers attendus.
- Exécution d'un script de remplacement (Python) qui a appliqué les deux remplacements dans `js/game.js` et `ads.html` et a signalé les fichiers mis à jour avec succès.
- Inspection du diff avec `git diff -- js/game.js ads.html` pour confirmer que les blocs ciblés ont été remplacés exactement comme demandé et que les modifications sont localement présentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac5a3cd748321a92b276cd6dc4c93)