### PR TITLE
Improve duel layout scaling, rematch UX, and disable duel interstitials

### DIFF
--- a/data/AR.json
+++ b/data/AR.json
@@ -291,5 +291,9 @@
   "referral.link_copied": "تم نسخ الرابط",
   "referral.crosspromo_desc": "ادعُ صديقًا لتثبيت VBlocks واحصل على مكافأة.",
   "referral.android_only_popup.text": "إصدار أندرويد فقط هو المتاح حاليًا. إصدار iOS قيد التطوير ولا يمكن تنزيله الآن.",
-  "common.continue": "متابعة"
+  "common.continue": "متابعة",
+  "duel.rematch": "مباراة إعادة",
+  "duel.rematch.sent": "تم إرسال طلب الإعادة",
+  "duel.rematch.ask": "خصمك يطلب مباراة إعادة. هل تقبل؟",
+  "duel.rematch.error": "تعذر بدء مباراة الإعادة الآن."
 }

--- a/data/DE.json
+++ b/data/DE.json
@@ -291,5 +291,9 @@
   "referral.link_copied": "Link kopiert",
   "referral.crosspromo_desc": "Lade einen Freund ein, VBlocks zu installieren, und erhalte eine Belohnung.",
   "referral.android_only_popup.text": "Zurzeit ist nur die Android-Version verfügbar. Die iOS-Version ist in Arbeit und kann momentan noch nicht heruntergeladen werden.",
-  "common.continue": "Weiter"
+  "common.continue": "Weiter",
+  "duel.rematch": "Revanche",
+  "duel.rematch.sent": "Revanche-Anfrage gesendet",
+  "duel.rematch.ask": "Dein Gegner möchte eine Revanche. Annehmen?",
+  "duel.rematch.error": "Eine Revanche kann im Moment nicht gestartet werden."
 }

--- a/data/EN.json
+++ b/data/EN.json
@@ -291,5 +291,9 @@
   "referral.link_copied": "Link copied",
   "referral.crosspromo_desc": "Invite a friend to install VBlocks and earn a reward.",
   "referral.android_only_popup.text": "Only the Android version is available for now. The iOS version is in progress and cannot be downloaded yet.",
-  "common.continue": "Continue"
+  "common.continue": "Continue",
+  "duel.rematch": "Rematch",
+  "duel.rematch.sent": "Rematch request sent",
+  "duel.rematch.ask": "Your opponent is asking for a rematch. Accept?",
+  "duel.rematch.error": "Unable to start a rematch right now."
 }

--- a/data/ES.json
+++ b/data/ES.json
@@ -291,5 +291,9 @@
   "referral.link_copied": "Enlace copiado",
   "referral.crosspromo_desc": "Invita a un amigo a instalar VBlocks y gana una recompensa.",
   "referral.android_only_popup.text": "Por ahora solo está disponible la versión Android. La versión iOS está en desarrollo y todavía no se puede descargar.",
-  "common.continue": "Continuar"
+  "common.continue": "Continuar",
+  "duel.rematch": "Revancha",
+  "duel.rematch.sent": "Solicitud de revancha enviada",
+  "duel.rematch.ask": "Tu rival propone una revancha. ¿Aceptar?",
+  "duel.rematch.error": "No se puede iniciar la revancha por ahora."
 }

--- a/data/FR.json
+++ b/data/FR.json
@@ -291,5 +291,9 @@
   "referral.link_copied": "Lien copié",
   "referral.crosspromo_desc": "Invite un ami à installer VBlocks et gagne une récompense.",
   "referral.android_only_popup.text": "Seule la version Android est disponible pour le moment. La version iOS est en cours et ne peut donc pas être téléchargée pour le moment.",
-  "common.continue": "Continuer"
+  "common.continue": "Continuer",
+  "duel.rematch": "Revanche",
+  "duel.rematch.sent": "Demande de revanche envoyée",
+  "duel.rematch.ask": "Ton adversaire propose une revanche. Accepter ?",
+  "duel.rematch.error": "Impossible de lancer la revanche pour le moment."
 }

--- a/data/IDN.json
+++ b/data/IDN.json
@@ -291,5 +291,9 @@
   "referral.link_copied": "Tautan disalin",
   "referral.crosspromo_desc": "Undang teman untuk menginstal VBlocks dan dapatkan hadiah.",
   "referral.android_only_popup.text": "Saat ini hanya versi Android yang tersedia. Versi iOS sedang dikerjakan dan belum bisa diunduh.",
-  "common.continue": "Lanjutkan"
+  "common.continue": "Lanjutkan",
+  "duel.rematch": "Tanding ulang",
+  "duel.rematch.sent": "Permintaan tanding ulang dikirim",
+  "duel.rematch.ask": "Lawanmu meminta tanding ulang. Terima?",
+  "duel.rematch.error": "Tidak bisa memulai tanding ulang sekarang."
 }

--- a/data/IT.json
+++ b/data/IT.json
@@ -291,5 +291,9 @@
   "referral.link_copied": "Link copiato",
   "referral.crosspromo_desc": "Invita un amico a installare VBlocks e guadagna una ricompensa.",
   "referral.android_only_popup.text": "Per il momento è disponibile solo la versione Android. La versione iOS è in lavorazione e non può ancora essere scaricata.",
-  "common.continue": "Continua"
+  "common.continue": "Continua",
+  "duel.rematch": "Rivincita",
+  "duel.rematch.sent": "Richiesta di rivincita inviata",
+  "duel.rematch.ask": "Il tuo avversario propone una rivincita. Accettare?",
+  "duel.rematch.error": "Impossibile avviare una rivincita al momento."
 }

--- a/data/JP.json
+++ b/data/JP.json
@@ -291,5 +291,9 @@
   "referral.link_copied": "リンクをコピーしました",
   "referral.crosspromo_desc": "友だちを VBlocks のインストールに招待して、報酬を獲得しよう。",
   "referral.android_only_popup.text": "現在利用できるのは Android 版のみです。iOS 版は開発中で、まだダウンロードできません。",
-  "common.continue": "続行"
+  "common.continue": "続行",
+  "duel.rematch": "再戦",
+  "duel.rematch.sent": "再戦リクエストを送信しました",
+  "duel.rematch.ask": "相手が再戦を希望しています。受けますか？",
+  "duel.rematch.error": "今は再戦を開始できません。"
 }

--- a/data/KO.json
+++ b/data/KO.json
@@ -291,5 +291,9 @@
   "referral.link_copied": "링크가 복사되었습니다",
   "referral.crosspromo_desc": "친구를 VBlocks 설치에 초대하고 보상을 받으세요.",
   "referral.android_only_popup.text": "현재는 Android 버전만 이용할 수 있습니다. iOS 버전은 개발 중이며 아직 다운로드할 수 없습니다.",
-  "common.continue": "계속"
+  "common.continue": "계속",
+  "duel.rematch": "재대결",
+  "duel.rematch.sent": "재대결 요청을 보냈습니다",
+  "duel.rematch.ask": "상대가 재대결을 원합니다. 수락할까요?",
+  "duel.rematch.error": "지금은 재대결을 시작할 수 없습니다."
 }

--- a/data/NL.json
+++ b/data/NL.json
@@ -291,5 +291,9 @@
   "referral.link_copied": "Link gekopieerd",
   "referral.crosspromo_desc": "Nodig een vriend uit om VBlocks te installeren en verdien een beloning.",
   "referral.android_only_popup.text": "Alleen de Android-versie is momenteel beschikbaar. De iOS-versie is in ontwikkeling en kan nog niet worden gedownload.",
-  "common.continue": "Doorgaan"
+  "common.continue": "Doorgaan",
+  "duel.rematch": "Rematch",
+  "duel.rematch.sent": "Rematch-verzoek verzonden",
+  "duel.rematch.ask": "Je tegenstander wil een rematch. Accepteren?",
+  "duel.rematch.error": "Kan nu geen rematch starten."
 }

--- a/data/PT-BR.json
+++ b/data/PT-BR.json
@@ -291,5 +291,9 @@
   "referral.link_copied": "Link copiado",
   "referral.crosspromo_desc": "Convide um amigo para instalar o VBlocks e ganhe uma recompensa.",
   "referral.android_only_popup.text": "Somente a versão Android está disponível no momento. A versão para iOS está em desenvolvimento e ainda não pode ser baixada.",
-  "common.continue": "Continuar"
+  "common.continue": "Continuar",
+  "duel.rematch": "Revanche",
+  "duel.rematch.sent": "Pedido de revanche enviado",
+  "duel.rematch.ask": "Seu adversário quer revanche. Aceitar?",
+  "duel.rematch.error": "Não foi possível iniciar a revanche agora."
 }

--- a/data/PT.json
+++ b/data/PT.json
@@ -291,5 +291,9 @@
   "referral.link_copied": "Ligação copiada",
   "referral.crosspromo_desc": "Convida um amigo a instalar o VBlocks e ganha uma recompensa.",
   "referral.android_only_popup.text": "Apenas a versão Android está disponível de momento. A versão iOS está em desenvolvimento e ainda não pode ser transferida.",
-  "common.continue": "Continuar"
+  "common.continue": "Continuar",
+  "duel.rematch": "Revanche",
+  "duel.rematch.sent": "Pedido de revanche enviado",
+  "duel.rematch.ask": "O teu adversário quer revanche. Aceitas?",
+  "duel.rematch.error": "Não foi possível iniciar a revanche agora."
 }

--- a/duel.html
+++ b/duel.html
@@ -16,33 +16,53 @@
   <link rel="stylesheet" href="themes/themes.css" id="theme-style" />
   <style>
     /* === mêmes bases que classic === */
+    :root {
+      --safe-top: env(safe-area-inset-top, 0px);
+      --safe-bottom: env(safe-area-inset-bottom, 0px);
+    }
+
     html, body {
-      margin: 0; padding: 0;
-      width: 100vw; height: 100dvh;
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      min-height: 100dvh;
+      height: 100dvh;
       box-sizing: border-box;
       font-family: 'Quicksand', Arial, sans-serif;
       background: var(--body-bg, #111);
       color: var(--body-color, #ccc);
       overflow: hidden;
-      height: 100%;
     }
+
     body {
-      display: flex; flex-direction: column;
-      min-height: 100dvh; height: 100dvh;
-      width: 100vw;
-      align-items: center; justify-content: flex-start;
+      min-height: 100dvh;
+      height: 100dvh;
+      width: 100%;
     }
+
+    .game-viewport {
+      position: fixed;
+      inset: 0;
+      overflow: hidden;
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+    }
+
     .main-content {
       display: flex;
       flex-direction: column;
-      width: 100vw;
-      max-width: 430px;
-      height: 100dvh;
-      min-height: 100dvh;
+      width: 430px;
+      max-width: none;
+      height: auto;
+      min-height: 0;
       box-sizing: border-box;
       align-items: center;
       justify-content: flex-start;
       margin: 0 auto;
+      padding-bottom: calc(var(--safe-bottom) + 14px);
+      transform-origin: top center;
+      will-change: transform;
     }
 
     /* === TOP BAR (comme classic) === */
@@ -289,10 +309,10 @@
 </style>
 </head>
 <body>
-  <!-- fond optionnel comme classic -->
   <canvas id="starfield" style="position:fixed; top:0; left:0; width:100vw; height:100vh; z-index:-1; display:none;"></canvas>
 
-  <div class="main-content">
+  <div class="game-viewport">
+    <div class="main-content">
     <!-- === BARRE TOP EXACTEMENT COMME CLASSIC === -->
     <div class="top-bar">
       <div class="top-bar-row">
@@ -362,6 +382,7 @@
     <div id="controls">
       <button id="music-btn" data-i18n="game.music">Musique</button>
       <button onclick="location.reload()" data-i18n="game.replay">Rejouer</button>
+    </div>
     </div>
   </div>
 

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -160,18 +160,51 @@ function fillRectThemeSafe(c, px, py, size) {
       c2d.restore();
     }
 
+    const mainContent = document.querySelector('.main-content');
+    let resizeRAF = null;
+
     function fitCanvasToCSS() {
-      const rect = canvas.getBoundingClientRect();
-      const cssW = Math.round(rect.width);
+      const cssW = Math.round(canvas.clientWidth || canvas.getBoundingClientRect().width);
+      if (!cssW) return;
+
       BLOCK_SIZE = cssW / COLS;
+
       const usedW = BLOCK_SIZE * COLS;
       const usedH = BLOCK_SIZE * ROWS;
 
       canvas.style.height = usedH + 'px';
-      canvas.width  = Math.round(usedW * DPR);
+      canvas.width = Math.round(usedW * DPR);
       canvas.height = Math.round(usedH * DPR);
+
       ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
     }
+
+    function fitWholeGameUI() {
+      if (!mainContent) return;
+
+      mainContent.style.transform = 'scale(1)';
+      mainContent.style.marginTop = '0px';
+
+      requestAnimationFrame(() => {
+        const vv = window.visualViewport;
+        const viewportW = Math.round(vv?.width || window.innerWidth || 430);
+        const viewportH = Math.round(vv?.height || window.innerHeight || 800);
+
+        const baseW = mainContent.offsetWidth || 430;
+        const baseH = Math.max(mainContent.scrollHeight, mainContent.offsetHeight, 1);
+        const FIT_BOTTOM_BUFFER = 30;
+
+        const scale = Math.min(
+          viewportW / baseW,
+          (viewportH - FIT_BOTTOM_BUFFER) / baseH,
+          1
+        );
+
+        mainContent.style.transform = `scale(${scale})`;
+        mainContent.style.marginTop = '0px';
+      });
+    }
+
     function boardOffsets() {
       const cssW = canvas.width / DPR;
       const cssH = canvas.height / DPR;
@@ -192,11 +225,49 @@ function fillRectThemeSafe(c, px, py, size) {
     fitCanvasToCSS();
     sizeMiniCanvas(holdCanvas, holdCtx, 48);
     sizeMiniCanvas(nextCanvas, nextCtx, 48);
-    window.addEventListener('resize', () => {
+    fitWholeGameUI();
+
+    window.addEventListener('load', () => {
       fitCanvasToCSS();
       sizeMiniCanvas(holdCanvas, holdCtx, 48);
       sizeMiniCanvas(nextCanvas, nextCtx, 48);
-      safeRedraw();
+      fitWholeGameUI();
+    });
+
+    if (document.fonts && document.fonts.ready) {
+      document.fonts.ready.then(() => {
+        fitCanvasToCSS();
+        sizeMiniCanvas(holdCanvas, holdCtx, 48);
+        sizeMiniCanvas(nextCanvas, nextCtx, 48);
+        fitWholeGameUI();
+      });
+    }
+
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('resize', () => {
+        fitCanvasToCSS();
+        fitWholeGameUI();
+      });
+    }
+
+    window.addEventListener('resize', () => {
+      cancelAnimationFrame(resizeRAF);
+      resizeRAF = requestAnimationFrame(() => {
+        if (mainContent) {
+          mainContent.style.transform = 'scale(1)';
+          mainContent.style.marginTop = '0px';
+        }
+
+        fitCanvasToCSS();
+        sizeMiniCanvas(holdCanvas, holdCtx, 48);
+        sizeMiniCanvas(nextCanvas, nextCtx, 48);
+
+        safeRedraw();
+        drawMiniPiece(holdCtx, heldPiece);
+        drawMiniPiece(nextCtx, nextPiece);
+
+        fitWholeGameUI();
+      });
     });
 
     // ====== Thèmes & assets ======
@@ -433,6 +504,94 @@ function fillRectThemeSafe(c, px, py, size) {
       return piecesSequence[piecesUsed++];
     }
 
+    async function requestRematch() {
+      try {
+        const uid = (window.getUserId ? await window.getUserId() : null);
+        if (!uid || !duelId) return;
+
+        const newCode = (typeof window.genDuelCode === 'function')
+          ? window.genDuelCode()
+          : Math.random().toString(36).slice(2, 8).toUpperCase();
+
+        const { data: created, error: createErr } = await sb.from('duels').insert([{
+          code: newCode,
+          player1: uid,
+          status: 'waiting'
+        }]).select().single();
+
+        if (createErr || !created?.id) {
+          console.error('[DUEL] create rematch failed', createErr);
+          alert(t('duel.rematch.error'));
+          return;
+        }
+
+        const { error: updErr } = await sb.from('duels')
+          .update({
+            rematch_requested_by: uid,
+            rematch_status: 'pending',
+            rematch_code: newCode
+          })
+          .eq('id', duelId);
+
+        if (updErr) {
+          console.error('[DUEL] update rematch failed', updErr);
+          alert(t('duel.rematch.error'));
+          return;
+        }
+
+        alert(t('duel.rematch.sent'));
+        pollRematch();
+      } catch (e) {
+        console.error(e);
+        alert(t('duel.rematch.error'));
+      }
+    }
+
+    async function pollRematch() {
+      let tries = 0;
+      while (tries++ < 120) {
+        const { data } = await sb.from('duels').select('*').eq('id', duelId).single();
+        if (!data) {
+          await new Promise(r => setTimeout(r, 1500));
+          continue;
+        }
+
+        if (data.rematch_status === 'accepted' && data.rematch_code) {
+          const uid = (window.getUserId ? await window.getUserId() : null);
+
+          let player = 2;
+          if (data.rematch_requested_by === uid) player = 1;
+
+          window.location.href = `duel.html?duel=${data.rematch_code}&player=${player}`;
+          return;
+        }
+
+        await new Promise(r => setTimeout(r, 1500));
+      }
+    }
+
+    async function watchIncomingRematchProposal() {
+      let tries = 0;
+      while (tries++ < 120) {
+        const uid = (window.getUserId ? await window.getUserId() : null);
+        const { data } = await sb.from('duels').select('*').eq('id', duelId).single();
+
+        if (data && data.rematch_status === 'pending' && data.rematch_requested_by && data.rematch_requested_by !== uid && data.rematch_code) {
+          const accept = confirm(t('duel.rematch.ask'));
+          if (!accept) return;
+
+          await sb.from('duels')
+            .update({ rematch_status: 'accepted' })
+            .eq('id', duelId);
+
+          window.location.href = `duel.html?duel=${data.rematch_code}&player=2`;
+          return;
+        }
+
+        await new Promise(r => setTimeout(r, 1500));
+      }
+    }
+
     async function handleDuelEnd(myScore) {
       const field = (duelPlayerNum === 1) ? 'score1' : 'score2';
       await sb.from('duels').update({ [field]: myScore }).eq('id', duelId);
@@ -455,14 +614,33 @@ function fillRectThemeSafe(c, px, py, size) {
       div.innerHTML = `
         <div style="background:#23294a;padding:2em 2em 1.1em 2em;border-radius:1.2em;box-shadow:0 0 12px #39ff1477;text-align:center;min-width:280px;max-width:92vw;">
           <div style="font-weight:bold;font-size:1.12em;">${t('duel.finished')}</div>
+
           <div style="margin-top:10px;">${t('duel.yourscore')} <b>${myScore}</b></div>
           <div>${t('duel.opponentscore')} <b>${otherScore != null ? otherScore : t('duel.waiting')}</b></div>
+
+          <button
+            id="duel-rematch-btn"
+            style="
+              width:100%;
+              margin-top:16px;
+              padding:.9em 1em;
+              border-radius:1em;
+              border:none;
+              background:linear-gradient(180deg,#ff9f2f 0%,#ff7b1e 100%);
+              color:#fff;
+              cursor:pointer;
+              font-weight:800;
+              box-shadow:0 0 14px rgba(255,160,60,.45);
+            "
+          >
+            ${t('duel.rematch')}
+          </button>
 
           <button
             id="duel-reward-vcoins"
             style="
               width:100%;
-              margin-top:16px;
+              margin-top:12px;
               padding:.85em 1em;
               border-radius:1em;
               border:none;
@@ -477,10 +655,10 @@ function fillRectThemeSafe(c, px, py, size) {
               font-weight:700;
             "
           >
-            <span>${t('end.reward.vcoins','Regarder une pub')}</span>
+            <span>${t('end.reward.vcoins')}</span>
             <span style="display:flex;align-items:center;gap:8px;font-weight:800;">
               <img src="assets/images/vcoin.webp" alt="" style="width:24px;height:24px;object-fit:contain;">
-              <span>+${rewardAmount} ${t('wallet.vcoins','VCoins')}</span>
+              <span>+${rewardAmount} ${t('wallet.vcoins')}</span>
             </span>
           </button>
 
@@ -497,16 +675,17 @@ function fillRectThemeSafe(c, px, py, size) {
 
       const btnReward = document.getElementById('duel-reward-vcoins');
       const btnBack = document.getElementById('duel-back-home');
+      const btnRematch = document.getElementById('duel-rematch-btn');
 
-      if (btnReward?.animate) {
-        btnReward.animate(
+      if (btnRematch?.animate) {
+        btnRematch.animate(
           [
-            { transform: 'scale(1)', boxShadow: '0 0 12px #39f7' },
-            { transform: 'scale(1.04)', boxShadow: '0 0 24px #39f7' },
-            { transform: 'scale(1)', boxShadow: '0 0 12px #39f7' }
+            { transform: 'scale(1)', boxShadow: '0 0 14px rgba(255,160,60,.35)' },
+            { transform: 'scale(1.05)', boxShadow: '0 0 24px rgba(255,160,60,.65)' },
+            { transform: 'scale(1)', boxShadow: '0 0 14px rgba(255,160,60,.35)' }
           ],
           {
-            duration: 1600,
+            duration: 1400,
             iterations: Infinity,
             easing: 'ease-in-out'
           }
@@ -514,8 +693,22 @@ function fillRectThemeSafe(c, px, py, size) {
       }
 
       if (btnBack) {
-        btnBack.onclick = function () {
-          window.location.href = 'index.html';
+        const goHome = function (e) {
+          e?.preventDefault?.();
+          e?.stopPropagation?.();
+          window.location.replace('index.html');
+        };
+
+        btnBack.addEventListener('click', goHome, { passive: false });
+        btnBack.addEventListener('touchend', goHome, { passive: false });
+        btnBack.style.touchAction = 'manipulation';
+      }
+
+      if (btnRematch) {
+        btnRematch.onclick = async function () {
+          btnRematch.disabled = true;
+          btnRematch.style.opacity = '.7';
+          await requestRematch();
         };
       }
 
@@ -548,10 +741,12 @@ function fillRectThemeSafe(c, px, py, size) {
           } catch (_) {
             btnReward.disabled = false;
             btnReward.style.opacity = '1';
-            alert(t('pub.err','Publicité indisponible pour le moment.'));
+            alert(t('pub.err'));
           }
         };
       }
+
+      watchIncomingRematchProposal();
     }
 
     function showEndPopup(points) {

--- a/js/pub.js
+++ b/js/pub.js
@@ -853,7 +853,6 @@
       return (
         path.endsWith('/classic.html') ||
         path.endsWith('/infini.html') ||
-        path.endsWith('/duel.html') ||
         path.endsWith('/concours.html') ||
         path.endsWith('/ads.html') ||
         path.endsWith('/game.html')
@@ -951,6 +950,11 @@
   }
 
   async function showInterstitial() {
+    try {
+      var path = (location.pathname || '').toLowerCase();
+      if (path.endsWith('/duel.html')) return false;
+    } catch (_) {}
+
     var watchdog = null;
     try {
       if (await hasNoAds()) { return false; }


### PR DESCRIPTION
### Motivation
- Make the duel screen reliably fit and scale on mobile (safe areas / visual viewport) so the game canvas and UI never get clipped or incorrectly sized.
- Prevent automatic interstitial ads from interrupting duels while providing a safe rematch workflow and clear end-of-duel UI with both players' scores.
- Harden touch navigation (back button) and make the rematch CTA more visible while avoiding unwanted reward-button animations.

### Description
- Reworked the `duel.html` root CSS and layout by adding `:root` safe-area variables, a fixed `.game-viewport` wrapper and a scaled `.main-content`, and updated the body opening/closing to nest the UI inside the viewport wrapper.
- Replaced and extended the canvas/UI sizing in `js/game_duel.js` by updating `fitCanvasToCSS`, adding `fitWholeGameUI`, and wiring resize/load/font/`visualViewport` handlers with a debounced resize RAF to keep canvas, mini-canvases and global scale consistent.
- Implemented rematch flow in `js/game_duel.js` with `requestRematch`, `pollRematch`, and `watchIncomingRematchProposal`, added a rematch button in the end popup, moved the pulsing animation to `#duel-rematch-btn`, and strengthened the back button handling (`click` + `touchend` + `replace`).
- Updated end-of-duel popup HTML to show player and opponent scores and kept the reward CTA while adjusting reward UI behavior.
- Excluded `duel.html` from auto interstitial eligibility by removing it from `isRealGameScreen()` and adding a guard at the top of `showInterstitial()` in `js/pub.js` to ensure interstitials never run on the duel page.
- Added new i18n keys for rematch messages in all supported language files (`data/*.json`).

### Testing
- Ran `node --check js/game_duel.js` which succeeded without syntax errors.
- Ran `node --check js/pub.js` which succeeded without syntax errors.
- Validated all `data/*.json` files by parsing them with Python `json.load`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbfbaa988c83218135c5421518d176)