### PR TITLE
Adjust touch repeat timing and vertical lock condition

### DIFF
--- a/js/concours.js
+++ b/js/concours.js
@@ -1866,8 +1866,8 @@ function fillRectThemeSafe(c, px, py, size) {
     const VERTICAL_LOCK_EARLY_MS = 140;
 
     // === AUTO-REPEAT HORIZONTAL (glissement continu) ===
-    const INITIAL_REPEAT_DELAY = 180; // délai avant répétition (ms)
-    const REPEAT_INTERVAL = 60;       // cadence pendant maintien (ms)
+    const INITIAL_REPEAT_DELAY = 100; // délai avant répétition (ms)
+    const REPEAT_INTERVAL = 55;       // cadence pendant maintien (ms)
     let horizDir = 0;                 // -1 gauche, 1 droite, 0 neutre
     let repeatKickoff = null;
     let repeatTicker = null;
@@ -1974,7 +1974,7 @@ function fillRectThemeSafe(c, px, py, size) {
       }
 
       // Passage en vertical
-      if (gestureMode === 'vertical' || softDropActive || elapsed >= VERTICAL_LOCK_EARLY_MS) {
+      if (gestureMode === 'vertical' || softDropActive) {
         gestureMode = 'vertical';
         rotationLocked = true; // 🔒 pendant vertical/softdrop
         stopHorizontalRepeat();


### PR DESCRIPTION
### Motivation
- Improve touch responsiveness by reducing horizontal auto-repeat startup delay and interval to make sliding feel more responsive.
- Prevent premature vertical lock based on elapsed time so vertical mode is only entered when explicitly vertical or during soft drop.

### Description
- In `js/concours.js` change `INITIAL_REPEAT_DELAY` from `180` to `100` and `REPEAT_INTERVAL` from `60` to `55` to speed up horizontal auto-repeat.
- Simplify the touch vertical-mode transition by removing the `elapsed >= VERTICAL_LOCK_EARLY_MS` check so the condition is now `gestureMode === 'vertical' || softDropActive`.
- All edits are confined to `js/concours.js` and do not alter other input or drop logic.

### Testing
- Ran `node --check js/concours.js` to verify there are no syntax errors and the file parses correctly, which succeeded.
- Performed a targeted file inspection to confirm the two replacements in `js/concours.js` were applied as intended, which matched the expected diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbffad986c83219c21a208e9181921)