### PR TITLE
Adjust vertical gesture lock condition in duel touch controls

### DIFF
--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -1227,7 +1227,7 @@ function fillRectThemeSafe(c, px, py, size) {
       movedX = t.clientX - startX;
       movedY = t.clientY - startY;
 
-      if (gestureMode === 'vertical' || softDropActive || elapsed >= VERTICAL_LOCK_EARLY_MS) {
+      if (gestureMode === 'vertical' || softDropActive) {
         gestureMode = 'vertical';
         if (!softDropActive && isQuickSwipeUp(elapsed, movedY)) {
           rotatePiece();


### PR DESCRIPTION
### Motivation
- Prevent premature locking into vertical gesture mode on touchmove which was triggered by an elapsed-time threshold, improving touch responsiveness in duel mode.

### Description
- Modified the touchmove gesture lock condition in `js/game_duel.js` to remove the elapsed-time early-lock check by changing `if (gestureMode === 'vertical' || softDropActive || elapsed >= VERTICAL_LOCK_EARLY_MS)` to `if (gestureMode === 'vertical' || softDropActive)`. 
- Committed the change to the repository; no other files were modified. 
- The requested auto-repeat timing constants (`INITIAL_REPEAT_DELAY = 180` / `REPEAT_INTERVAL = 60`) were not found in `js/game.js` or `js/game_duel.js`, so those replacements were not applied (similar constants exist elsewhere with different values). 

### Testing
- Verified the code change with `git diff -- js/game_duel.js` which showed the updated conditional and succeeded. 
- Searched the codebase with `rg` to confirm presence/absence of the requested constants which returned no matches for the specified values. 
- Committed the change successfully with `git commit` and no automated test suite was executed for this small input-logic change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc027176e48321baf4fe901bd57c5c)