### PR TITLE
Improve horizontal touch-repeat timing and remove vertical early-lock threshold

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -2026,7 +2026,10 @@ if (score > highscoreCloud) {
 
     // ===== Repeat horizontal tactile =====
     let horizontalRepeatInterval = null;
+    let horizontalRepeatKickoff = null;
     let horizontalRepeatDirection = 0;
+    const INITIAL_REPEAT_DELAY = 100; // délai avant répétition (ms)
+    const REPEAT_INTERVAL = 55; // cadence pendant maintien (ms)
 
     function startHorizontalRepeat(direction) {
       if (paused || gameOver || window.__ads_active) return;
@@ -2040,16 +2043,24 @@ if (score > highscoreCloud) {
       move(direction);
       safeRedraw();
 
-      horizontalRepeatInterval = setInterval(() => {
-        if (!paused && !gameOver && !window.__ads_active) {
-          move(direction);
-          safeRedraw();
-        }
-      }, 120);
+      horizontalRepeatKickoff = setTimeout(() => {
+        horizontalRepeatKickoff = null;
+        horizontalRepeatInterval = setInterval(() => {
+          if (!paused && !gameOver && !window.__ads_active) {
+            move(direction);
+            safeRedraw();
+          }
+        }, REPEAT_INTERVAL);
+      }, INITIAL_REPEAT_DELAY);
     }
 
     function stopHorizontalRepeat() {
       horizontalRepeatDirection = 0;
+
+      if (horizontalRepeatKickoff) {
+        clearTimeout(horizontalRepeatKickoff);
+        horizontalRepeatKickoff = null;
+      }
 
       if (horizontalRepeatInterval) {
         clearInterval(horizontalRepeatInterval);
@@ -2101,7 +2112,6 @@ if (score > highscoreCloud) {
     let gestureMode = 'none';
     const HORIZ_THRESHOLD = 20;
     const DEAD_ZONE = 10;
-    const VERTICAL_LOCK_EARLY_MS = 140;
     const HOLD_ACTIVATION_MS = 180;
 
     let didHardDrop = false;
@@ -2178,7 +2188,7 @@ if (score > highscoreCloud) {
         return;
       }
 
-      if (gestureMode === 'vertical' || isSoftDropping || elapsed >= VERTICAL_LOCK_EARLY_MS) {
+      if (gestureMode === 'vertical' || isSoftDropping) {
         gestureMode = 'vertical';
         rotationLocked = true;
         stopHorizontalRepeat();

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -1227,7 +1227,7 @@ function fillRectThemeSafe(c, px, py, size) {
       movedX = t.clientX - startX;
       movedY = t.clientY - startY;
 
-      if (gestureMode === 'vertical' || softDropActive || elapsed >= VERTICAL_LOCK_EARLY_MS) {
+      if (gestureMode === 'vertical' || softDropActive) {
         gestureMode = 'vertical';
         if (!softDropActive && isQuickSwipeUp(elapsed, movedY)) {
           rotatePiece();


### PR DESCRIPTION
### Motivation
- Make horizontal touch-hold movement feel more responsive by introducing a short initial delay before repeat and a faster repeat cadence during hold. 
- Ensure pending kickoff timers are cleared when stopping horizontal repeats to avoid stray movement after cancel. 
- Simplify vertical gesture locking by removing the now-unused early vertical-lock timeout check to rely on existing soft-drop state.

### Description
- Added `horizontalRepeatKickoff`, `INITIAL_REPEAT_DELAY` (100ms) and `REPEAT_INTERVAL` (55ms) and changed horizontal repeat logic to perform one immediate move then start a kickoff `setTimeout` before entering the repeating `setInterval` loop. 
- Replaced the previous fixed 120ms repeating interval with the new two-stage model and added cleanup to clear the kickoff timeout in `stopHorizontalRepeat`. 
- Removed the `VERTICAL_LOCK_EARLY_MS` usage and related elapsed-time check in touch-move handlers, changing conditions to rely on the soft-drop/vertical state in both `js/game.js` and `js/game_duel.js`. 
- Kept existing safety guards for pause/gameOver/ads and ensured the immediate move+redraw behavior on touch still occurs.

### Testing
- Ran the project linters with `npm run lint` and the task completed successfully. 
- Executed the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc027176e48321baf4fe901bd57c5c)