### PR TITLE
Adjust touch repeat timing and vertical gesture lock

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -2025,6 +2025,9 @@ if (score > highscoreCloud) {
     }
 
     // ===== Repeat horizontal tactile =====
+    const INITIAL_REPEAT_DELAY = 100; // délai avant répétition (ms)
+    const REPEAT_INTERVAL = 55;       // cadence pendant maintien (ms)
+    let horizontalRepeatTimeout = null;
     let horizontalRepeatInterval = null;
     let horizontalRepeatDirection = 0;
 
@@ -2040,16 +2043,23 @@ if (score > highscoreCloud) {
       move(direction);
       safeRedraw();
 
-      horizontalRepeatInterval = setInterval(() => {
-        if (!paused && !gameOver && !window.__ads_active) {
-          move(direction);
-          safeRedraw();
-        }
-      }, 120);
+      horizontalRepeatTimeout = setTimeout(() => {
+        horizontalRepeatInterval = setInterval(() => {
+          if (!paused && !gameOver && !window.__ads_active) {
+            move(direction);
+            safeRedraw();
+          }
+        }, REPEAT_INTERVAL);
+      }, INITIAL_REPEAT_DELAY);
     }
 
     function stopHorizontalRepeat() {
       horizontalRepeatDirection = 0;
+
+      if (horizontalRepeatTimeout) {
+        clearTimeout(horizontalRepeatTimeout);
+        horizontalRepeatTimeout = null;
+      }
 
       if (horizontalRepeatInterval) {
         clearInterval(horizontalRepeatInterval);
@@ -2178,7 +2188,7 @@ if (score > highscoreCloud) {
         return;
       }
 
-      if (gestureMode === 'vertical' || isSoftDropping || elapsed >= VERTICAL_LOCK_EARLY_MS) {
+      if (gestureMode === 'vertical' || isSoftDropping) {
         gestureMode = 'vertical';
         rotationLocked = true;
         stopHorizontalRepeat();


### PR DESCRIPTION
### Motivation
- Reduce latency and increase responsiveness for horizontal touch holds by lowering the initial repeat delay and the repeat interval. 
- Avoid accidental vertical lock during short horizontal drags by removing the elapsed-time fallback from the vertical gesture condition.

### Description
- Add `INITIAL_REPEAT_DELAY = 100` and `REPEAT_INTERVAL = 55` and a `horizontalRepeatTimeout` variable in `js/game.js` to control initial hold delay and repeat cadence. 
- Change `startHorizontalRepeat` to schedule the repeated moves with a `setTimeout` that starts a `setInterval` after the initial delay. 
- Ensure `stopHorizontalRepeat` clears both the pending timeout and the running interval. 
- Simplify the touch vertical-lock check by replacing `if (gestureMode === 'vertical' || isSoftDropping || elapsed >= VERTICAL_LOCK_EARLY_MS)` with `if (gestureMode === 'vertical' || isSoftDropping)`.

### Testing
- Verified the presence of new constants and variables with `rg -n` checks, which succeeded. 
- Confirmed the code changes by inspecting the diff with `git diff -- js/game.js` and viewing file snippets with `nl`, which succeeded. 
- Committed the updated `js/game.js` with `git commit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc058c529c8321a1337656e706141f)