### PR TITLE
Update touch horizontal repeat behavior in ads game

### DIFF
--- a/ads.html
+++ b/ads.html
@@ -1864,29 +1864,38 @@ if (score > highscoreCloud) {
     // ===== Repeat horizontal tactile =====
     let horizontalRepeatInterval = null;
     let horizontalRepeatDirection = 0;
+    let horizontalRepeatKickoff = null;
 
     function startHorizontalRepeat(direction) {
       if (paused || gameOver || window.__ads_active) return;
       if (direction !== -1 && direction !== 1) return;
 
-      if (horizontalRepeatDirection === direction && horizontalRepeatInterval) return;
+      if (
+        horizontalRepeatDirection === direction &&
+        (horizontalRepeatInterval || horizontalRepeatKickoff)
+      ) return;
 
       stopHorizontalRepeat();
       horizontalRepeatDirection = direction;
 
-      move(direction);
-      safeRedraw();
+      horizontalRepeatKickoff = setTimeout(() => {
+        horizontalRepeatKickoff = null;
 
-      horizontalRepeatInterval = setInterval(() => {
-        if (!paused && !gameOver && !window.__ads_active) {
-          move(direction);
-          safeRedraw();
-        }
-      }, 120);
+        horizontalRepeatInterval = setInterval(() => {
+          if (!paused && !gameOver && !window.__ads_active) {
+            move(direction);
+          }
+        }, 60);
+      }, 180);
     }
 
     function stopHorizontalRepeat() {
       horizontalRepeatDirection = 0;
+
+      if (horizontalRepeatKickoff) {
+        clearTimeout(horizontalRepeatKickoff);
+        horizontalRepeatKickoff = null;
+      }
 
       if (horizontalRepeatInterval) {
         clearInterval(horizontalRepeatInterval);
@@ -2039,13 +2048,17 @@ if (score > highscoreCloud) {
       }
 
       if (gestureMode === 'horizontal') {
-        if (movedX > HORIZ_THRESHOLD) {
+        if (movedX > HORIZ_THRESHOLD)  {
+          move(1);
+          startX = t.clientX;
           startHorizontalRepeat(1);
-          startX = t.clientX;
         } else if (movedX < -HORIZ_THRESHOLD) {
-          startHorizontalRepeat(-1);
+          move(-1);
           startX = t.clientX;
-        } else {
+          startHorizontalRepeat(-1);
+        }
+
+        if (Math.abs(movedX) <= HORIZ_THRESHOLD) {
           stopHorizontalRepeat();
         }
 


### PR DESCRIPTION
### Motivation
- Improve touch horizontal input responsiveness and avoid immediate continuous repetition when the user first swipes horizontally in the ads game.
- Ensure the repeat lifecycle is robust by adding a kickoff delay before entering a fast repeat interval and properly clearing both timeout and interval.

### Description
- Modified `ads.html` to add `horizontalRepeatKickoff` and use a kickoff `setTimeout` before starting the repeating `setInterval` in `startHorizontalRepeat` instead of moving immediately inside the function.
- Changed duplicate-start check in `startHorizontalRepeat` to consider both `horizontalRepeatInterval` and `horizontalRepeatKickoff` when deciding to no-op.
- Updated `stopHorizontalRepeat` to clear both the kickoff timeout and the repeating interval via `clearTimeout` and `clearInterval` respectively.
- Updated the `canvas` `touchmove` gesture handling to perform an immediate single-step `move(±1)` then call `startHorizontalRepeat`, and to call `stopHorizontalRepeat()` when `Math.abs(movedX) <= HORIZ_THRESHOLD`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0a806fe48321891d764d50a37b1e)