### PR TITLE
Adjust horizontal touch repeat behavior in game

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -2121,29 +2121,28 @@ if (score > highscoreCloud) {
 
     // ===== Repeat horizontal tactile =====
     let horizontalRepeatInterval = null;
-    let horizontalRepeatKickoff = null;
     let horizontalRepeatDirection = 0;
-    const INITIAL_REPEAT_DELAY = 100; // délai avant répétition (ms)
-    const REPEAT_INTERVAL = 55; // cadence pendant maintien (ms)
+    let horizontalRepeatKickoff = null;
+    const INITIAL_REPEAT_DELAY = 180;
+    const REPEAT_INTERVAL = 60;
 
     function startHorizontalRepeat(direction) {
       if (paused || gameOver || window.__ads_active) return;
       if (direction !== -1 && direction !== 1) return;
 
-      if (horizontalRepeatDirection === direction && horizontalRepeatInterval) return;
+      if (
+        horizontalRepeatDirection === direction &&
+        (horizontalRepeatInterval || horizontalRepeatKickoff)
+      ) return;
 
       stopHorizontalRepeat();
       horizontalRepeatDirection = direction;
-
-      move(direction);
-      safeRedraw();
 
       horizontalRepeatKickoff = setTimeout(() => {
         horizontalRepeatKickoff = null;
         horizontalRepeatInterval = setInterval(() => {
           if (!paused && !gameOver && !window.__ads_active) {
             move(direction);
-            safeRedraw();
           }
         }, REPEAT_INTERVAL);
       }, INITIAL_REPEAT_DELAY);
@@ -2308,12 +2307,16 @@ if (score > highscoreCloud) {
 
       if (gestureMode === 'horizontal') {
         if (movedX > HORIZ_THRESHOLD) {
+          move(1);
+          startX = t.clientX;
           startHorizontalRepeat(1);
-          startX = t.clientX;
         } else if (movedX < -HORIZ_THRESHOLD) {
-          startHorizontalRepeat(-1);
+          move(-1);
           startX = t.clientX;
-        } else {
+          startHorizontalRepeat(-1);
+        }
+
+        if (Math.abs(movedX) <= HORIZ_THRESHOLD) {
           stopHorizontalRepeat();
         }
 


### PR DESCRIPTION
### Motivation
- Improve touch horizontal sliding to avoid immediate double-moves and to provide a delayed auto-repeat that feels more natural on mobile.
- Prevent duplicate repeat startup when a kickoff timer or an active interval is already pending.
- Make threshold crossing produce an immediate single move and then enable hold-to-repeat behavior.

### Description
- Replaced the horizontal auto-repeat implementation in `js/game.js` to set `INITIAL_REPEAT_DELAY` to `180` and `REPEAT_INTERVAL` to `60`, reordered the repeat variables, and removed the immediate `move`/`safeRedraw` from `startHorizontalRepeat` so the repeat loop only handles sustained movement.
- Tightened the prevention condition in `startHorizontalRepeat` to return when the same direction is requested while either `horizontalRepeatInterval` or `horizontalRepeatKickoff` is active.
- Updated the `touchmove`/gesture horizontal handling to call `move(1)` or `move(-1)` immediately on threshold crossing, then call `startHorizontalRepeat(...)`, and to call `stopHorizontalRepeat()` when `Math.abs(movedX) <= HORIZ_THRESHOLD`.

### Testing
- Ran repository checks and inspections: `rg -n "Repeat horizontal tactile|gestureMode === 'horizontal'|INITIAL_REPEAT_DELAY"` (succeeded) and `sed -n` to inspect the modified ranges in `js/game.js` (succeeded).
- Verified the `git diff` and committed the change with `git commit` (succeeded); no automated unit tests were run for this JavaScript behavior change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0e360ab0832183624202d5a5ccb5)