### PR TITLE
Restore early vertical-lock condition in touch gestures

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -2208,6 +2208,7 @@ if (score > highscoreCloud) {
     let gestureMode = 'none';
     const HORIZ_THRESHOLD = 20;
     const DEAD_ZONE = 10;
+    const VERTICAL_LOCK_EARLY_MS = 140;
     const HOLD_ACTIVATION_MS = 180;
 
     let didHardDrop = false;
@@ -2284,7 +2285,7 @@ if (score > highscoreCloud) {
         return;
       }
 
-      if (gestureMode === 'vertical' || isSoftDropping) {
+      if (gestureMode === 'vertical' || isSoftDropping || elapsed >= VERTICAL_LOCK_EARLY_MS) {
         gestureMode = 'vertical';
         rotationLocked = true;
         stopHorizontalRepeat();


### PR DESCRIPTION
### Motivation
- Réintroduire le verrou vertical précoce dans le gestionnaire de gestes tactiles pour que le passage en mode vertical se déclenche aussi quand `elapsed` dépasse le seuil temporel attendu.

### Description
- Ajout de la constante `const VERTICAL_LOCK_EARLY_MS = 140;` et mise à jour de la condition en `if (gestureMode === 'vertical' || isSoftDropping || elapsed >= VERTICAL_LOCK_EARLY_MS)` dans `js/game.js`, sans modifier les blocs horizontaux adjacents.

### Testing
- Vérification du diff du fichier montrant uniquement les deux lignes modifiées dans `js/game.js` et inspection de l’état du dépôt qui n’a montré pas d’autres changements, ces contrôles ont réussi; aucun test automatisé de comportement n’a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1168e21c832186f5ad5dd691c847)