### PR TITLE
Update language selector layout and ES-LATAM globe rendering

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -56,9 +56,27 @@
       ui: "ES-LATAM",
       aria: "Español (LatAm)",
       flag: `<svg viewBox="0 0 30 20" aria-hidden="true">
-    <rect width="30" height="20" rx="4" fill="#ffffff"/>
-    <circle cx="15" cy="10" r="6.2" fill="#2bb3a3"/>
-    <path d="M15 3.8c-1.9 1.1-3.3 2.7-4.1 4.7c1.2-.4 2.3-.4 3.3-.1c-.8 1-1.2 2.2-1.3 3.5c1.5-.8 3.2-1.1 5-.9c-.7.9-1.1 1.9-1.2 3.1c2.1-1.1 3.6-3 4.1-5.3c-.9.3-1.8.5-2.8.4c.5-.9.7-1.8.7-2.8c-1 .6-2.1 1-3.2 1.1c.1-1.2-.1-2.4-.5-3.7Z" fill="#ffffff" opacity="0.98"/>
+    <defs>
+      <radialGradient id="latamGlobePopup" cx="35%" cy="30%" r="75%">
+        <stop offset="0%" stop-color="#63e1ff"/>
+        <stop offset="55%" stop-color="#29c7d8"/>
+        <stop offset="100%" stop-color="#16b575"/>
+      </radialGradient>
+      <filter id="latamGlow" x="-60%" y="-60%" width="220%" height="220%">
+        <feGaussianBlur stdDeviation="1.2" result="blur"/>
+        <feMerge>
+          <feMergeNode in="blur"/>
+          <feMergeNode in="SourceGraphic"/>
+        </feMerge>
+      </filter>
+    </defs>
+    <g filter="url(#latamGlow)">
+      <circle cx="15" cy="10" r="7.2" fill="url(#latamGlobePopup)"/>
+      <ellipse cx="15" cy="10" rx="5.5" ry="7.2" fill="none" stroke="rgba(255,255,255,.95)" stroke-width="1"/>
+      <ellipse cx="15" cy="10" rx="2.8" ry="7.2" fill="none" stroke="rgba(255,255,255,.88)" stroke-width="0.9"/>
+      <path d="M8.1 10h13.8M9.4 6.5h11.2M9.4 13.5h11.2" stroke="rgba(255,255,255,.88)" stroke-width="0.9" stroke-linecap="round"/>
+      <path d="M12.5 6.4c.7-.7 1.5-1.2 2.4-1.5c.9.2 1.7.8 2.4 1.6c.6.5 1.3.9 2.1 1.2c-.2 1.1-.8 2-1.7 2.7c-.4.4-.6 1-.6 1.6c-1.1.2-2.1 0-3-.5c-.7-.3-1.3-.8-1.8-1.4c-.4-.5-1-1-1.7-1.2c.2-1 .8-1.9 1.9-2.5Z" fill="rgba(255,255,255,.98)"/>
+    </g>
   </svg>`
     },
     {
@@ -335,10 +353,10 @@
       }
 
       .vrLangOverlay .vr-flagBox{
-        width:46px;
-        height:32px;
+        width:50px;
+        height:34px;
         border-radius:8px;
-        overflow:hidden;
+        overflow:visible;
         border:0 !important;
         outline:0 !important;
         box-shadow:none !important;

--- a/parametres.html
+++ b/parametres.html
@@ -95,21 +95,67 @@
     }
     label { font-weight: 800; font-size: 1.1em; display: block; margin-bottom: 0.6em; }
     .lang-select {
-      display: flex; flex-wrap: wrap; gap: 0.7em; justify-content: center; margin-top: 0.5em;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.75em 0.8em;
+      margin-top: 0.65em;
+      align-items: stretch;
     }
     .lang-option {
-      display: flex; align-items: center; gap: 0.5em;
-      padding: 0.35em 0.85em; border-radius: 1em;
-      background: #e6f6ea; color: #156c31; border: none; font-weight: 700;
-      cursor: pointer; box-shadow: 0 2px 8px #a2dcd220;
-      transition: background 0.13s, transform 0.13s;
-      font-size: 1.08em;
+      width: 100%;
+      min-height: 44px;
+      box-sizing: border-box;
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+      gap: 0.55em;
+      padding: 0.42em 0.85em;
+      border-radius: 999px;
+      background: #eaf7e9;
+      color: #156c31;
+      border: none;
+      font-weight: 700;
+      cursor: pointer;
+      box-shadow: 0 2px 8px #a2dcd220;
+      transition: background 0.13s, transform 0.13s, box-shadow 0.13s;
+      font-size: 1.02em;
+      text-align: left;
+    }
+    .lang-option span {
+      display: block;
+      line-height: 1.1;
+      white-space: nowrap;
     }
     .lang-option.selected {
-      background: linear-gradient(90deg,#70dcff 0%,#b2ff9d 100%);
-      color: #0e4b26; transform: scale(1.06);
+      background: linear-gradient(90deg, #70dcff 0%, #b2ff9d 100%);
+      color: #0e4b26;
+      transform: scale(1.03);
+      box-shadow: 0 8px 18px rgba(63, 184, 203, 0.22);
     }
-    .flag { width: 22px; height: 16px; }
+    .flag {
+      width: 22px;
+      height: 16px;
+      flex: 0 0 22px;
+      display: block;
+    }
+    /* si nombre impair, le dernier se centre proprement */
+    .lang-option:last-child:nth-child(odd) {
+      grid-column: 1 / -1;
+      justify-self: center;
+      width: calc(50% - 0.4em);
+    }
+    @media (max-width: 380px) {
+      .lang-option {
+        padding: 0.4em 0.72em;
+        font-size: 0.95em;
+      }
+
+      .flag {
+        width: 20px;
+        height: 15px;
+        flex-basis: 20px;
+      }
+    }
     .switch {
       display: flex; align-items: center; gap: 0.8em; margin-top: 0.7em;
     }
@@ -160,11 +206,13 @@
       }
 
       .lang-select {
-        gap: 0.9em;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.9em 1em;
       }
 
       .lang-option {
-        font-size: 1.03em;
+        font-size: 1.04em;
+        min-height: 48px;
       }
 
       .switch {
@@ -276,7 +324,19 @@
       { code: "DE",   label: "Deutsch",         flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="22" height="5.33" fill="#000"/><rect y="5.33" width="22" height="5.33" fill="#dd0000"/><rect y="10.67" width="22" height="5.33" fill="#ffce00"/></svg>` },
       { code: "IT",   label: "Italiano",        flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="7.33" height="16" fill="#009246"/><rect x="7.33" width="7.34" height="16" fill="#fff"/><rect x="14.67" width="7.33" height="16" fill="#ce2b37"/></svg>` },
       { code: "ES",   label: "Español",         flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="22" height="16" fill="#aa151b"/><rect y="4" width="22" height="8" fill="#f1bf00"/></svg>` },
-      { code: "ES-LATAM", label: "Español (LatAm)", flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="22" height="16" rx="2" fill="#ffffff"/><circle cx="11" cy="8" r="5" fill="#2bb3a3"/><path d="M11 3.3c-1.6.9-2.7 2.2-3.4 4c1-.3 1.9-.3 2.7-.1c-.6.9-1 1.9-1 3c1.2-.7 2.6-.9 4.1-.8c-.6.7-.9 1.6-1 2.6c1.7-.9 2.9-2.5 3.4-4.5c-.7.3-1.5.4-2.3.4c.4-.7.6-1.5.6-2.4c-.8.5-1.7.8-2.7.9c.1-1-.1-2-.4-3.1Z" fill="#fff" opacity="0.98"/></svg>` },
+      { code: "ES-LATAM", label: "Español (LatAm)", flag: `<svg class="flag" viewBox="0 0 22 16" aria-hidden="true">
+    <defs>
+      <linearGradient id="latamGlobeSettings" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stop-color="#41d6ff"/>
+        <stop offset="100%" stop-color="#1bbf8a"/>
+      </linearGradient>
+    </defs>
+    <circle cx="11" cy="8" r="6.1" fill="url(#latamGlobeSettings)"/>
+    <ellipse cx="11" cy="8" rx="4.6" ry="6.1" fill="none" stroke="rgba(255,255,255,.92)" stroke-width="0.9"/>
+    <ellipse cx="11" cy="8" rx="2.2" ry="6.1" fill="none" stroke="rgba(255,255,255,.85)" stroke-width="0.8"/>
+    <path d="M4.9 8h12.2M6.1 5.2h9.8M6.1 10.8h9.8" stroke="rgba(255,255,255,.85)" stroke-width="0.8" stroke-linecap="round"/>
+    <path d="M9.2 5.2c.5-.5 1.1-.9 1.7-1.1c.7.2 1.2.6 1.7 1.2c.4.4.9.7 1.5.9c-.2.8-.6 1.4-1.2 1.9c-.3.3-.4.7-.4 1.1c-.8.1-1.5 0-2.1-.4c-.5-.2-.9-.6-1.2-1c-.3-.4-.7-.6-1.2-.8c.1-.7.5-1.3 1.2-1.8Z" fill="rgba(255,255,255,.96)"/>
+  </svg>` },
       { code: "PT",   label: "Português",       flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="8" height="16" fill="#00874B"/><rect x="8" width="14" height="16" fill="#FF0000"/><circle cx="9.5" cy="8" r="3.3" fill="#fff" stroke="#FFD700" stroke-width="1"/><rect x="8.6" y="5.5" width="1.8" height="5" fill="#00874B" stroke="#FFD700" stroke-width="0.5"/><circle cx="9.5" cy="8" r="1.2" fill="#00874B" stroke="#FFD700" stroke-width="0.4"/></svg>` },
       { code: "PT-BR",label: "Português (BR)",  flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="22" height="16" fill="#3eae47"/><ellipse cx="11" cy="8" rx="8" ry="6" fill="#ffcc29"/><circle cx="11" cy="8" r="4" fill="#3e4095"/><path d="M8.3 8.4a3 3 0 0 1 5.4 0" stroke="#fff" stroke-width=".8" fill="none"/><text x="11" y="10.5" font-size="3.3" fill="#fff" text-anchor="middle" alignment-baseline="middle" font-family="Arial">BR</text></svg>` },
       { code: "NL",   label: "Nederlands",      flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="22" height="5.33" fill="#ae1e28"/><rect y="5.33" width="22" height="5.33" fill="#fff"/><rect y="10.67" width="22" height="5.33" fill="#21468b"/></svg>` },


### PR DESCRIPTION
### Motivation
- Modernize the language picker UI to a two-column grid with better sizing, alignment and responsive behavior.
- Replace the rough ES-LATAM flag with a proper globe SVG in both the settings page and the i18n popup so it matches other flags visually.
- Ensure language-picker popup flag container has the correct size/overflow so the new globe SVGs render without clipping.

### Description
- Replaced the `.lang-select` / `.lang-option` CSS block in `parametres.html` with a two-column grid layout, updated spacing, selected-state styling, odd-item centering rule and small-screen adjustments.
- Updated the `@media (min-width: 768px)` rules in `parametres.html` to set `grid-template-columns`, `gap` and increased `min-height` for options.
- Replaced the `ES-LATAM` entry in `const LANGS` inside `parametres.html` with the provided globe SVG to remove the white square and match size/appearance.
- Replaced the `ES-LATAM` entry in `const LANGUAGE_CHOICES` inside `js/i18n.js` with the provided globe+glow SVG, and updated `.vrLangOverlay .vr-flagBox` in `ensureLanguagePickerStyles()` to `width:50px`, `height:34px` and `overflow:visible`.

### Testing
- Ran `git diff --check` to ensure no whitespace issues and it completed successfully.
- Ran `git status --short` to confirm modified files and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc5a6228c83218fa16d1316157973)