### PR TITLE
Update language selectors layout and ES-LATAM flag SVG

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -56,15 +56,21 @@
       ui: "ES-LATAM",
       aria: "Español (LatAm)",
       flag: `<svg viewBox="0 0 30 20" aria-hidden="true">
+    <defs>
+      <radialGradient id="latamGlobeReal1" cx="35%" cy="30%" r="75%">
+        <stop offset="0%" stop-color="#8ff3ff"/>
+        <stop offset="45%" stop-color="#34d7ff"/>
+        <stop offset="78%" stop-color="#1dc6c8"/>
+        <stop offset="100%" stop-color="#0ea56f"/>
+      </radialGradient>
+    </defs>
     <g transform="translate(5,0)">
-      <circle cx="10" cy="10" r="8.2" fill="#2fd3dd"/>
-      <circle cx="10" cy="10" r="8.2" fill="#000" opacity=".08"/>
-      <path d="M10 1.8a8.2 8.2 0 0 1 0 16.4a6.1 8.2 0 0 0 0-16.4Z" fill="#17b6a8" opacity=".95"/>
-      <ellipse cx="10" cy="10" rx="5.9" ry="8.2" fill="none" stroke="#fff" stroke-width=".9" opacity=".94"/>
-      <ellipse cx="10" cy="10" rx="2.6" ry="8.2" fill="none" stroke="#fff" stroke-width=".7" opacity=".8"/>
-      <path d="M2.4 10h15.2M3.6 6.4h12.8M3.6 13.6h12.8" stroke="#fff" stroke-width=".7" stroke-linecap="round" opacity=".82"/>
-      <path d="M7.4 5.1c1.5-1 3.2-1.1 4.7-.4c.8.4 1.8.8 2.8 1c-.3 1.2-1 2.1-2 2.8c-.6.4-.9 1-.9 1.7c-1.1.2-2.1 0-3-.6c-.6-.4-1.2-.9-1.8-1.4c-.5-.3-1.1-.6-1.9-.8c.2-.9.9-1.6 2.1-2.3Z" fill="#fff" opacity=".98"/>
-      <path d="M6.4 11.8c.8 0 1.6.3 2.3.8c.8.7 1.9 1.1 3.1 1.1c.9 0 1.7.3 2.5.8c-.8 1.3-1.9 2.2-3.4 2.8c-1.9-.1-3.5-.8-4.8-2.1c-.7-.8-.8-2 .3-3.4Z" fill="#fff" opacity=".9"/>
+      <circle cx="10" cy="10" r="8.1" fill="url(#latamGlobeReal1)"/>
+      <ellipse cx="10" cy="10" rx="5.7" ry="8.1" fill="none" stroke="#fff" stroke-width=".8" opacity=".92"/>
+      <ellipse cx="10" cy="10" rx="2.6" ry="8.1" fill="none" stroke="#fff" stroke-width=".65" opacity=".78"/>
+      <path d="M2.5 10h15M3.8 6.3h12.4M3.8 13.7h12.4" stroke="#fff" stroke-width=".65" stroke-linecap="round" opacity=".82"/>
+      <path d="M7.1 4.9c1.4-.9 3-1 4.4-.4c.8.4 1.7.8 2.6.9c-.3 1.1-1 2-1.9 2.7c-.5.4-.8 1-.9 1.7c-1 .2-1.9 0-2.8-.6c-.6-.4-1.1-.9-1.7-1.3c-.5-.3-1-.6-1.7-.8c.2-.8.9-1.5 2-2.2Z" fill="#fff" opacity=".98"/>
+      <path d="M6.2 11.7c.8 0 1.5.3 2.2.8c.8.7 1.8 1 2.9 1c.9 0 1.6.2 2.3.7c-.7 1.2-1.8 2-3.2 2.6c-1.8-.1-3.3-.8-4.5-2c-.7-.8-.8-1.9.3-3.1Z" fill="#fff" opacity=".9"/>
     </g>
   </svg>`
     },
@@ -300,26 +306,19 @@
       .vrLangOverlay .vr-langGrid{
         display:grid;
         grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap:14px 10px;
+        gap:10px;
         margin-top:22px;
         margin-bottom:6px;
       }
 
-      @media (min-width: 520px){
-        .vrLangOverlay .vr-langGrid{
-          grid-template-columns: repeat(4, minmax(0, 1fr));
-        }
-      }
-
       .vrLangOverlay .vr-langBtn{
         width:100%;
-        min-width:0;
         display:flex;
         flex-direction:column;
         align-items:center;
         justify-content:flex-start;
         gap:7px;
-        padding:10px 4px 12px;
+        padding:10px 4px 8px;
         border-radius:14px;
         border:0 !important;
         background:transparent !important;
@@ -328,15 +327,13 @@
         cursor:pointer;
         -webkit-tap-highlight-color: transparent;
         text-align:center;
-        appearance:none;
-        overflow:hidden;
       }
 
       .vrLangOverlay .vr-langBtn:active{
         transform:scale(.98);
       }
 
-      .vrLangOverlay .vr-langBtn.isActive{
+      .vrLangOverlay .vr-langBtn.isSelected{
         outline:0;
         box-shadow:0 0 0 2px rgba(255,255,255,.22), 0 14px 34px rgba(0,0,0,.26) !important;
         background:transparent !important;
@@ -344,18 +341,15 @@
       }
 
       .vrLangOverlay .vr-flagBox{
-        width:48px;
+        width:46px;
         height:32px;
         border-radius:8px;
-        overflow:visible;
+        overflow:hidden;
         border:0 !important;
         outline:0 !important;
         box-shadow:none !important;
         background:transparent !important;
         flex:0 0 auto;
-        display:flex;
-        align-items:center;
-        justify-content:center;
       }
 
       .vrLangOverlay .vr-flagBox svg{
@@ -365,21 +359,16 @@
       }
 
       .vrLangOverlay .vr-langText{
-        display:flex !important;
-        align-items:flex-start;
-        justify-content:center;
-        min-height:30px;
-        font-size:clamp(10px,2.5vw,12px);
+        display:block !important;
+        width:100%;
+        min-height:24px;
+        font-size:10px;
         font-weight:800;
-        line-height:1.08;
+        line-height:1.15;
         color:rgba(255,255,255,.96);
         text-align:center;
-        overflow:hidden;
-      }
-
-      .vrLangOverlay .vr-langText > div{
-        max-width:82px;
-        overflow-wrap:anywhere;
+        white-space:normal;
+        word-break:break-word;
       }
 
       .vrLangActions{
@@ -458,7 +447,7 @@
       function refreshActiveState() {
         buttons.forEach((btn) => {
           const isOn = btn.getAttribute("data-lang") === selected;
-          btn.classList.toggle("isActive", isOn);
+          btn.classList.toggle("isSelected", isOn);
         });
 
         if (confirmBtn) {

--- a/parametres.html
+++ b/parametres.html
@@ -94,70 +94,73 @@
       box-sizing: border-box;
     }
     label { font-weight: 800; font-size: 1.1em; display: block; margin-bottom: 0.6em; }
-    .lang-select {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 0.7em 0.75em;
-      margin-top: 0.5em;
-      align-items: stretch;
+    .lang-select{
+      display:grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap:10px;
+      margin-top:22px;
+      margin-bottom:22px;
     }
-    .lang-option {
-      width: 100%;
-      min-width: 0;
-      min-height: 42px;
-      display: flex;
-      align-items: center;
-      gap: 0.55em;
-      padding: 0.4em 0.8em;
-      border-radius: 999px;
-      background: #e6f6ea;
-      color: #156c31;
-      border: none;
-      font-weight: 700;
-      cursor: pointer;
-      box-shadow: 0 2px 8px #a2dcd220;
-      transition: background 0.13s, transform 0.13s;
-      font-size: 0.98em;
-      box-sizing: border-box;
-      overflow: hidden;
-    }
-    .lang-option.selected {
-      background: linear-gradient(90deg,#70dcff 0%,#b2ff9d 100%);
-      color: #0e4b26;
-      transform: scale(1.03);
-    }
-    .flag {
-      width: 22px;
-      height: 16px;
-      flex: 0 0 22px;
-      display: block;
-    }
-    .lang-label {
-      min-width: 0;
-      flex: 1 1 auto;
-      display: block;
-      font-size: 0.98em;
-      line-height: 1.05;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .lang-option:last-child:nth-child(odd) {
-      grid-column: 1 / -1;
-      justify-self: center;
-      width: calc(50% - 0.38em);
-    }
-    @media (max-width: 380px) {
-      .lang-option {
-        padding: 0.4em 0.72em;
-        font-size: 0.95em;
-      }
 
-      .flag {
-        width: 20px;
-        height: 15px;
-        flex-basis: 20px;
+    @media (min-width: 520px){
+      .lang-select{
+        grid-template-columns: repeat(4, minmax(0, 1fr));
       }
+    }
+
+    .lang-option{
+      width:100%;
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      justify-content:flex-start;
+      gap:7px;
+      padding:10px 4px 8px;
+      border-radius:14px;
+      border:0 !important;
+      background:transparent !important;
+      box-shadow:none !important;
+      color:inherit;
+      cursor:pointer;
+      -webkit-tap-highlight-color: transparent;
+      text-align:center;
+    }
+
+    .lang-option:active{
+      transform:scale(.98);
+    }
+
+    .lang-option.selected{
+      outline:0;
+      box-shadow:0 0 0 2px rgba(255,255,255,.22), 0 14px 34px rgba(0,0,0,.26) !important;
+      background:transparent !important;
+      border:0 !important;
+    }
+
+    .flag{
+      width:46px;
+      height:32px;
+      border-radius:8px;
+      overflow:hidden;
+      border:0 !important;
+      outline:0 !important;
+      box-shadow:none !important;
+      background:transparent !important;
+      flex:0 0 auto;
+      display:block;
+    }
+
+    .lang-label{
+      display:block !important;
+      width:100%;
+      min-height:24px;
+      font-size:10px;
+      font-weight:800;
+      line-height:1.15;
+      color:rgba(255,255,255,.96);
+      text-align:center;
+      white-space:normal;
+      word-break:break-word;
     }
     .switch {
       display: flex; align-items: center; gap: 0.8em; margin-top: 0.7em;
@@ -206,16 +209,6 @@
         max-width: 720px;
         border-radius: 1.8em;
         padding: 1.35em 1.6em;
-      }
-
-      .lang-select {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 0.9em 1em;
-      }
-
-      .lang-option {
-        min-height: 46px;
-        font-size: 1em;
       }
 
       .switch {
@@ -327,16 +320,22 @@
       { code: "DE",   label: "Deutsch",         flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="22" height="5.33" fill="#000"/><rect y="5.33" width="22" height="5.33" fill="#dd0000"/><rect y="10.67" width="22" height="5.33" fill="#ffce00"/></svg>` },
       { code: "IT",   label: "Italiano",        flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="7.33" height="16" fill="#009246"/><rect x="7.33" width="7.34" height="16" fill="#fff"/><rect x="14.67" width="7.33" height="16" fill="#ce2b37"/></svg>` },
       { code: "ES",   label: "Español",         flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="22" height="16" fill="#aa151b"/><rect y="4" width="22" height="8" fill="#f1bf00"/></svg>` },
-      { code: "ES-LATAM", label: "Español (LatAm)", flag: `<svg class="flag" viewBox="0 0 22 16" aria-hidden="true">
-    <g transform="translate(3,0)">
-      <circle cx="8" cy="8" r="6.7" fill="#2fd3dd"/>
-      <circle cx="8" cy="8" r="6.7" fill="#000" opacity=".08"/>
-      <path d="M8 1.3a6.7 6.7 0 0 1 0 13.4a5.1 6.7 0 0 0 0-13.4Z" fill="#17b6a8" opacity=".95"/>
-      <ellipse cx="8" cy="8" rx="4.8" ry="6.7" fill="none" stroke="#fff" stroke-width=".7" opacity=".92"/>
-      <ellipse cx="8" cy="8" rx="2.1" ry="6.7" fill="none" stroke="#fff" stroke-width=".55" opacity=".78"/>
-      <path d="M1.8 8h12.4M2.8 5.1h10.4M2.8 10.9h10.4" stroke="#fff" stroke-width=".55" stroke-linecap="round" opacity=".8"/>
-      <path d="M6 4.2c1.2-.8 2.6-.9 3.8-.3c.7.3 1.5.7 2.3.8c-.2 1-.8 1.7-1.6 2.2c-.5.3-.7.8-.8 1.4c-.9.2-1.7 0-2.4-.5c-.5-.3-.9-.8-1.4-1.1c-.4-.3-.9-.5-1.5-.7c.2-.7.7-1.3 1.6-1.8Z" fill="#fff" opacity=".97"/>
-      <path d="M5.2 9.5c.7 0 1.3.2 1.8.6c.7.6 1.5.9 2.5.9c.8 0 1.4.2 2 .7c-.6 1.1-1.5 1.8-2.7 2.2c-1.5-.1-2.8-.6-3.8-1.7c-.6-.7-.7-1.6.2-2.7Z" fill="#fff" opacity=".9"/>
+      { code: "ES-LATAM", label: "Español (LatAm)", flag: `<svg viewBox="0 0 30 20" aria-hidden="true">
+    <defs>
+      <radialGradient id="latamGlobeReal1" cx="35%" cy="30%" r="75%">
+        <stop offset="0%" stop-color="#8ff3ff"/>
+        <stop offset="45%" stop-color="#34d7ff"/>
+        <stop offset="78%" stop-color="#1dc6c8"/>
+        <stop offset="100%" stop-color="#0ea56f"/>
+      </radialGradient>
+    </defs>
+    <g transform="translate(5,0)">
+      <circle cx="10" cy="10" r="8.1" fill="url(#latamGlobeReal1)"/>
+      <ellipse cx="10" cy="10" rx="5.7" ry="8.1" fill="none" stroke="#fff" stroke-width=".8" opacity=".92"/>
+      <ellipse cx="10" cy="10" rx="2.6" ry="8.1" fill="none" stroke="#fff" stroke-width=".65" opacity=".78"/>
+      <path d="M2.5 10h15M3.8 6.3h12.4M3.8 13.7h12.4" stroke="#fff" stroke-width=".65" stroke-linecap="round" opacity=".82"/>
+      <path d="M7.1 4.9c1.4-.9 3-1 4.4-.4c.8.4 1.7.8 2.6.9c-.3 1.1-1 2-1.9 2.7c-.5.4-.8 1-.9 1.7c-1 .2-1.9 0-2.8-.6c-.6-.4-1.1-.9-1.7-1.3c-.5-.3-1-.6-1.7-.8c.2-.8.9-1.5 2-2.2Z" fill="#fff" opacity=".98"/>
+      <path d="M6.2 11.7c.8 0 1.5.3 2.2.8c.8.7 1.8 1 2.9 1c.9 0 1.6.2 2.3.7c-.7 1.2-1.8 2-3.2 2.6c-1.8-.1-3.3-.8-4.5-2c-.7-.8-.8-1.9.3-3.1Z" fill="#fff" opacity=".9"/>
     </g>
   </svg>` },
       { code: "PT",   label: "Português",       flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="8" height="16" fill="#00874B"/><rect x="8" width="14" height="16" fill="#FF0000"/><circle cx="9.5" cy="8" r="3.3" fill="#fff" stroke="#FFD700" stroke-width="1"/><rect x="8.6" y="5.5" width="1.8" height="5" fill="#00874B" stroke="#FFD700" stroke-width="0.5"/><circle cx="9.5" cy="8" r="1.2" fill="#00874B" stroke="#FFD700" stroke-width="0.4"/></svg>` },
@@ -364,7 +363,10 @@ function renderLanguageOptions() {
   LANGS.forEach(l => {
     const opt = document.createElement('div');
     opt.className = 'lang-option' + (l.code === selectedLang ? ' selected' : '');
-    opt.innerHTML = l.flag + '<span class="lang-label">' + l.label + '</span>';
+    opt.innerHTML = `
+  <span class="flag">${l.flag}</span>
+  <span class="lang-label">${l.label}</span>
+`;
 
     opt.onclick = async () => {
       if (window.setLang) {


### PR DESCRIPTION
### Motivation
- Standardize language pickers to a compact card/grid layout with flag above label for both settings and the initial language popup. 
- Provide a cleaner, readable globe SVG for the `ES-LATAM` entry to avoid the small white-square globe and improve visual clarity. 
- Align popup picker styles and selection class names with the settings page for consistent UX.

### Description
- Replaced the language selector CSS block in `parametres.html` with a 3-column grid (4 columns at >=520px) and card-style `.lang-option` rules matching the requested design. 
- Changed settings option rendering in `parametres.html` to use the requested template: ``opt.innerHTML = `\n  <span class="flag">${l.flag}</span>\n  <span class="lang-label">${l.label}</span>\n`;`` so `l.flag` must be the SVG only. 
- Replaced the `ES-LATAM` SVG in the `LANGS` array inside `parametres.html` with the provided radial-globe SVG. 
- Updated `js/i18n.js` `ensureLanguagePickerStyles()` with the matching grid/button/flag/text CSS block and replaced the `ES-LATAM` SVG in `LANGUAGE_CHOICES` with the same globe SVG. 
- Updated popup picker selection toggling to use the `isSelected` class (and adjusted CSS) so the popup reflects the same selected visual state as the settings page.

### Testing
- Ran `node --check js/i18n.js` to validate the modified JS file and it completed with no syntax errors. 
- Attempted `node --check parametres.html` but Node does not accept `.html` files for syntax checking, so no automated HTML syntax check was possible for that file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dccdf684ac8321babaf52aa56b7fe6)