### PR TITLE
Replace ES-LATAM SVG and adjust flag container styles

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -55,23 +55,15 @@
       code: "ES-LATAM",
       ui: "ES-LATAM",
       aria: "Español (LatAm)",
-      flag: `<svg viewBox="0 0 30 20" aria-hidden="true">
-    <defs>
-      <radialGradient id="latamGlobeReal1" cx="35%" cy="30%" r="75%">
-        <stop offset="0%" stop-color="#8ff3ff"/>
-        <stop offset="45%" stop-color="#34d7ff"/>
-        <stop offset="78%" stop-color="#1dc6c8"/>
-        <stop offset="100%" stop-color="#0ea56f"/>
-      </radialGradient>
-    </defs>
-    <g transform="translate(5,0)">
-      <circle cx="10" cy="10" r="8.1" fill="url(#latamGlobeReal1)"/>
-      <ellipse cx="10" cy="10" rx="5.7" ry="8.1" fill="none" stroke="#fff" stroke-width=".8" opacity=".92"/>
-      <ellipse cx="10" cy="10" rx="2.6" ry="8.1" fill="none" stroke="#fff" stroke-width=".65" opacity=".78"/>
-      <path d="M2.5 10h15M3.8 6.3h12.4M3.8 13.7h12.4" stroke="#fff" stroke-width=".65" stroke-linecap="round" opacity=".82"/>
-      <path d="M7.1 4.9c1.4-.9 3-1 4.4-.4c.8.4 1.7.8 2.6.9c-.3 1.1-1 2-1.9 2.7c-.5.4-.8 1-.9 1.7c-1 .2-1.9 0-2.8-.6c-.6-.4-1.1-.9-1.7-1.3c-.5-.3-1-.6-1.7-.8c.2-.8.9-1.5 2-2.2Z" fill="#fff" opacity=".98"/>
-      <path d="M6.2 11.7c.8 0 1.5.3 2.2.8c.8.7 1.8 1 2.9 1c.9 0 1.6.2 2.3.7c-.7 1.2-1.8 2-3.2 2.6c-1.8-.1-3.3-.8-4.5-2c-.7-.8-.8-1.9.3-3.1Z" fill="#fff" opacity=".9"/>
-    </g>
+      flag: `<svg viewBox="0 0 260 280" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path
+      d="M 143.9 157.2 L 130.3 148.1 L 115.0 123.2 L 119.3 113.0 L 115.9 108.3 L 127.1 94.0 L 124.0 80.9 L 120.0 79.1 L 116.1 84.1 L 102.1 76.2 L 96.7 66.3 L 49.9 51.7 L 21.6 14.0 L 16.4 13.3 L 31.3 38.4 L 16.1 24.1 L 18.7 21.6 L 10.0 10.0 L 41.1 12.3 L 48.6 19.6 L 57.3 19.2 L 63.0 28.0 L 68.5 29.5 L 66.9 41.1 L 76.4 52.1 L 87.1 48.8 L 88.6 43.8 L 98.0 42.2 L 92.5 58.7 L 108.7 60.5 L 107.5 72.7 L 112.2 78.9 L 119.9 77.1 L 127.9 79.9 L 133.6 72.8 L 142.8 68.8 L 143.0 78.7 L 148.1 69.6 L 153.2 74.3 L 171.7 74.1 L 178.3 79.4 L 180.4 72.7 L 180.9 80.7 L 185.4 83.7 L 186.3 82.2 L 184.3 77.9 L 187.0 76.2 L 185.4 74.0 L 192.3 76.7 L 191.8 79.7 L 197.6 79.0 L 203.1 82.7 L 205.8 88.8 L 214.3 92.4 L 225.7 95.2 L 231.7 100.0 L 235.2 107.8 L 243.8 116.3 L 250.0 124.7 L 249.9 141.1 L 241.5 149.4 L 237.5 164.9 L 234.6 179.4 L 223.3 184.8 L 209.0 189.3 L 204.1 198.5 L 191.8 213.9 L 185.6 222.2 L 171.9 227.2 L 169.1 231.5 L 160.4 235.5 L 160.0 240.5 L 155.7 245.3 L 158.9 249.3 L 150.8 255.7 L 153.0 257.0 L 152.3 261.5 L 142.8 268.3 L 125.3 261.8 L 123.2 250.7 L 129.0 240.4 L 126.6 239.1 L 131.2 228.6 L 132.8 224.2 L 137.6 202.8 L 142.5 185.5 L 142.2 168.0 L 135.6 161.0 Z"
+      fill="none"
+      stroke="#174e6a"
+      stroke-width="4.2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
   </svg>`
     },
     {
@@ -343,8 +335,8 @@
       .vrLangOverlay .vr-flagBox{
         width:46px;
         height:32px;
-        border-radius:8px;
-        overflow:hidden;
+        border-radius:0;
+        overflow:visible;
         border:0 !important;
         outline:0 !important;
         box-shadow:none !important;

--- a/parametres.html
+++ b/parametres.html
@@ -140,13 +140,19 @@
     .flag{
       width:46px;
       height:32px;
-      border-radius:8px;
-      overflow:hidden;
+      border-radius:0;
+      overflow:visible;
       border:0 !important;
       outline:0 !important;
       box-shadow:none !important;
       background:transparent !important;
       flex:0 0 auto;
+      display:block;
+    }
+
+    .flag svg{
+      width:100%;
+      height:100%;
       display:block;
     }
 
@@ -320,23 +326,15 @@
       { code: "DE",   label: "Deutsch",         flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="22" height="5.33" fill="#000"/><rect y="5.33" width="22" height="5.33" fill="#dd0000"/><rect y="10.67" width="22" height="5.33" fill="#ffce00"/></svg>` },
       { code: "IT",   label: "Italiano",        flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="7.33" height="16" fill="#009246"/><rect x="7.33" width="7.34" height="16" fill="#fff"/><rect x="14.67" width="7.33" height="16" fill="#ce2b37"/></svg>` },
       { code: "ES",   label: "Español",         flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="22" height="16" fill="#aa151b"/><rect y="4" width="22" height="8" fill="#f1bf00"/></svg>` },
-      { code: "ES-LATAM", label: "Español (LatAm)", flag: `<svg viewBox="0 0 30 20" aria-hidden="true">
-    <defs>
-      <radialGradient id="latamGlobeReal1" cx="35%" cy="30%" r="75%">
-        <stop offset="0%" stop-color="#8ff3ff"/>
-        <stop offset="45%" stop-color="#34d7ff"/>
-        <stop offset="78%" stop-color="#1dc6c8"/>
-        <stop offset="100%" stop-color="#0ea56f"/>
-      </radialGradient>
-    </defs>
-    <g transform="translate(5,0)">
-      <circle cx="10" cy="10" r="8.1" fill="url(#latamGlobeReal1)"/>
-      <ellipse cx="10" cy="10" rx="5.7" ry="8.1" fill="none" stroke="#fff" stroke-width=".8" opacity=".92"/>
-      <ellipse cx="10" cy="10" rx="2.6" ry="8.1" fill="none" stroke="#fff" stroke-width=".65" opacity=".78"/>
-      <path d="M2.5 10h15M3.8 6.3h12.4M3.8 13.7h12.4" stroke="#fff" stroke-width=".65" stroke-linecap="round" opacity=".82"/>
-      <path d="M7.1 4.9c1.4-.9 3-1 4.4-.4c.8.4 1.7.8 2.6.9c-.3 1.1-1 2-1.9 2.7c-.5.4-.8 1-.9 1.7c-1 .2-1.9 0-2.8-.6c-.6-.4-1.1-.9-1.7-1.3c-.5-.3-1-.6-1.7-.8c.2-.8.9-1.5 2-2.2Z" fill="#fff" opacity=".98"/>
-      <path d="M6.2 11.7c.8 0 1.5.3 2.2.8c.8.7 1.8 1 2.9 1c.9 0 1.6.2 2.3.7c-.7 1.2-1.8 2-3.2 2.6c-1.8-.1-3.3-.8-4.5-2c-.7-.8-.8-1.9.3-3.1Z" fill="#fff" opacity=".9"/>
-    </g>
+      { code: "ES-LATAM", label: "Español (LatAm)", flag: `<svg class="flag" viewBox="0 0 260 280" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path
+      d="M 143.9 157.2 L 130.3 148.1 L 115.0 123.2 L 119.3 113.0 L 115.9 108.3 L 127.1 94.0 L 124.0 80.9 L 120.0 79.1 L 116.1 84.1 L 102.1 76.2 L 96.7 66.3 L 49.9 51.7 L 21.6 14.0 L 16.4 13.3 L 31.3 38.4 L 16.1 24.1 L 18.7 21.6 L 10.0 10.0 L 41.1 12.3 L 48.6 19.6 L 57.3 19.2 L 63.0 28.0 L 68.5 29.5 L 66.9 41.1 L 76.4 52.1 L 87.1 48.8 L 88.6 43.8 L 98.0 42.2 L 92.5 58.7 L 108.7 60.5 L 107.5 72.7 L 112.2 78.9 L 119.9 77.1 L 127.9 79.9 L 133.6 72.8 L 142.8 68.8 L 143.0 78.7 L 148.1 69.6 L 153.2 74.3 L 171.7 74.1 L 178.3 79.4 L 180.4 72.7 L 180.9 80.7 L 185.4 83.7 L 186.3 82.2 L 184.3 77.9 L 187.0 76.2 L 185.4 74.0 L 192.3 76.7 L 191.8 79.7 L 197.6 79.0 L 203.1 82.7 L 205.8 88.8 L 214.3 92.4 L 225.7 95.2 L 231.7 100.0 L 235.2 107.8 L 243.8 116.3 L 250.0 124.7 L 249.9 141.1 L 241.5 149.4 L 237.5 164.9 L 234.6 179.4 L 223.3 184.8 L 209.0 189.3 L 204.1 198.5 L 191.8 213.9 L 185.6 222.2 L 171.9 227.2 L 169.1 231.5 L 160.4 235.5 L 160.0 240.5 L 155.7 245.3 L 158.9 249.3 L 150.8 255.7 L 153.0 257.0 L 152.3 261.5 L 142.8 268.3 L 125.3 261.8 L 123.2 250.7 L 129.0 240.4 L 126.6 239.1 L 131.2 228.6 L 132.8 224.2 L 137.6 202.8 L 142.5 185.5 L 142.2 168.0 L 135.6 161.0 Z"
+      fill="none"
+      stroke="#174e6a"
+      stroke-width="4.2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
   </svg>` },
       { code: "PT",   label: "Português",       flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="8" height="16" fill="#00874B"/><rect x="8" width="14" height="16" fill="#FF0000"/><circle cx="9.5" cy="8" r="3.3" fill="#fff" stroke="#FFD700" stroke-width="1"/><rect x="8.6" y="5.5" width="1.8" height="5" fill="#00874B" stroke="#FFD700" stroke-width="0.5"/><circle cx="9.5" cy="8" r="1.2" fill="#00874B" stroke="#FFD700" stroke-width="0.4"/></svg>` },
       { code: "PT-BR",label: "Português (BR)",  flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="22" height="16" fill="#3eae47"/><ellipse cx="11" cy="8" rx="8" ry="6" fill="#ffcc29"/><circle cx="11" cy="8" r="4" fill="#3e4095"/><path d="M8.3 8.4a3 3 0 0 1 5.4 0" stroke="#fff" stroke-width=".8" fill="none"/><text x="11" y="10.5" font-size="3.3" fill="#fff" text-anchor="middle" alignment-baseline="middle" font-family="Arial">BR</text></svg>` },


### PR DESCRIPTION
### Motivation
- Replace the existing ES-LATAM globe artwork with the provided path-based SVG so the Latino Spanish option uses the requested illustration. 
- Prevent thin strokes in the new SVG from being clipped by current flag container styling. 

### Description
- Replaced the `ES-LATAM` language option block in `parametres.html` with the supplied path-based SVG and added `.flag svg` sizing rules. 
- Replaced the `ES-LATAM` block in `js/i18n.js` (language choices) with the same path-based SVG. 
- Updated the settings page `.flag` rule in `parametres.html` to `border-radius:0` and `overflow:visible` and added a `.flag svg{ width:100%; height:100%; display:block; }` rule. 
- Updated the overlay picker styles in `ensureLanguagePickerStyles()` inside `js/i18n.js` by changing `.vrLangOverlay .vr-flagBox` to `border-radius:0` and `overflow:visible` while keeping the `.vr-flagBox svg` sizing rules. 

### Testing
- Searched for relevant occurrences with `rg` and confirmed the `ES-LATAM`, `.flag` and `vr-flagBox` locations were updated successfully. 
- Ran the Python replace script which completed and printed `done`. 
- Verified repository changes with `git -C /workspace/Vblocks status --short` and committed the modifications with `git commit`, both of which completed successfully. 
- Inspected the last commit with `git -C /workspace/Vblocks show --stat --oneline -1` and confirmed the two files (`parametres.html`, `js/i18n.js`) were updated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcdd30a6188321bf7b2cbaac20f07e)