### PR TITLE
Update ES-LATAM label and replace KO flag SVG in settings and i18n

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -54,7 +54,7 @@
     {
       code: "ES-LATAM",
       ui: "ES-LATAM",
-      aria: "Español (Amérique latine)",
+      aria: "Español (Latinoamérica)",
       flag: `<svg viewBox="0 0 30 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <rect x="0" y="0" width="30" height="20" fill="#ffffff"/>
     <g transform="translate(6.9 1.4) scale(0.062)">
@@ -116,45 +116,12 @@
       ui: "KO",
       aria: "한국어",
       flag: `<svg viewBox="0 0 30 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-  <rect width="30" height="20" fill="#ffffff"/>
-
-  <g transform="translate(15 10)">
-    <path d="M0-4.4A4.4 4.4 0 0 1 0 4.4A2.2 2.2 0 0 0 0 0A2.2 2.2 0 0 1 0-4.4Z" fill="#cd2e3a"/>
-    <path d="M0 4.4A4.4 4.4 0 0 1 0-4.4A2.2 2.2 0 0 0 0 0A2.2 2.2 0 0 1 0 4.4Z" fill="#0047a0"/>
-  </g>
-
-  <g fill="#111111">
-    <g transform="translate(6.2 4.6) rotate(-28)">
-      <rect x="-2.9" y="-2.8" width="5.8" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="-1.1" width="5.8" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="0.6" width="5.8" height="0.7" rx="0.2"/>
+    <rect width="30" height="20" fill="#ffffff"/>
+    <g transform="translate(15 10)">
+      <path d="M0-4.4A4.4 4.4 0 0 1 0 4.4A2.2 2.2 0 0 0 0 0A2.2 2.2 0 0 1 0-4.4Z" fill="#cd2e3a"/>
+      <path d="M0 4.4A4.4 4.4 0 0 1 0-4.4A2.2 2.2 0 0 0 0 0A2.2 2.2 0 0 1 0 4.4Z" fill="#0047a0"/>
     </g>
-
-    <g transform="translate(23.8 4.6) rotate(28)">
-      <rect x="-2.9" y="-2.8" width="5.8" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="0.6" width="5.8" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="-1.1" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="0.7" y="-1.1" width="2.2" height="0.7" rx="0.2"/>
-    </g>
-
-    <g transform="translate(6.2 15.4) rotate(28)">
-      <rect x="-2.9" y="-2.8" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="0.7" y="-2.8" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="-1.1" width="5.8" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="0.6" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="0.7" y="0.6" width="2.2" height="0.7" rx="0.2"/>
-    </g>
-
-    <g transform="translate(23.8 15.4) rotate(-28)">
-      <rect x="-2.9" y="-2.8" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="0.7" y="-2.8" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="-1.1" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="0.7" y="-1.1" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="0.6" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="0.7" y="0.6" width="2.2" height="0.7" rx="0.2"/>
-    </g>
-  </g>
-</svg>`
+  </svg>`
     }
   ];
 

--- a/parametres.html
+++ b/parametres.html
@@ -328,7 +328,7 @@
       { code: "ES",   label: "Español",         flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="22" height="16" fill="#aa151b"/><rect y="4" width="22" height="8" fill="#f1bf00"/></svg>` },
       {
   code: "ES-LATAM",
-  label: "Español (Amérique latine)",
+  label: "Español (Latinoamérica)",
   flag: `<svg class="flag" viewBox="0 0 30 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <rect x="0" y="0" width="30" height="20" fill="#ffffff"/>
     <g transform="translate(6.9 1.4) scale(0.062)">
@@ -349,46 +349,17 @@
       { code: "AR",   label: "العربية",         flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="22" height="16" fill="#fff"/><rect width="22" height="8" y="0" fill="#198754"/><polygon points="5,8 13,4 13,12" fill="#fff"/><circle cx="16" cy="8" r="3" fill="#198754"/></svg>` },
       { code: "IDN",  label: "Bahasa Indonesia",flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="22" height="8" y="0" fill="#ff0000"/><rect width="22" height="8" y="8" fill="#fff"/></svg>` },
       { code: "JP",   label: "日本語",          flag: `<svg class="flag" viewBox="0 0 22 16"><rect width="22" height="16" fill="#fff"/><circle cx="11" cy="8" r="4" fill="#bc002d"/></svg>` },
-      { code: "KO",   label: "한국어",           flag: `<svg class="flag" viewBox="0 0 30 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-  <rect width="30" height="20" fill="#ffffff"/>
-
-  <g transform="translate(15 10)">
-    <path d="M0-4.4A4.4 4.4 0 0 1 0 4.4A2.2 2.2 0 0 0 0 0A2.2 2.2 0 0 1 0-4.4Z" fill="#cd2e3a"/>
-    <path d="M0 4.4A4.4 4.4 0 0 1 0-4.4A2.2 2.2 0 0 0 0 0A2.2 2.2 0 0 1 0 4.4Z" fill="#0047a0"/>
-  </g>
-
-  <g fill="#111111">
-    <g transform="translate(6.2 4.6) rotate(-28)">
-      <rect x="-2.9" y="-2.8" width="5.8" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="-1.1" width="5.8" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="0.6" width="5.8" height="0.7" rx="0.2"/>
+      {
+  code: "KO",
+  label: "한국어",
+  flag: `<svg class="flag" viewBox="0 0 30 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <rect width="30" height="20" fill="#ffffff"/>
+    <g transform="translate(15 10)">
+      <path d="M0-4.4A4.4 4.4 0 0 1 0 4.4A2.2 2.2 0 0 0 0 0A2.2 2.2 0 0 1 0-4.4Z" fill="#cd2e3a"/>
+      <path d="M0 4.4A4.4 4.4 0 0 1 0-4.4A2.2 2.2 0 0 0 0 0A2.2 2.2 0 0 1 0 4.4Z" fill="#0047a0"/>
     </g>
-
-    <g transform="translate(23.8 4.6) rotate(28)">
-      <rect x="-2.9" y="-2.8" width="5.8" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="0.6" width="5.8" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="-1.1" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="0.7" y="-1.1" width="2.2" height="0.7" rx="0.2"/>
-    </g>
-
-    <g transform="translate(6.2 15.4) rotate(28)">
-      <rect x="-2.9" y="-2.8" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="0.7" y="-2.8" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="0.6" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="0.7" y="0.6" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="-1.1" width="5.8" height="0.7" rx="0.2"/>
-    </g>
-
-    <g transform="translate(23.8 15.4) rotate(-28)">
-      <rect x="-2.9" y="-2.8" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="0.7" y="-2.8" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="-1.1" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="0.7" y="-1.1" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="-2.9" y="0.6" width="2.2" height="0.7" rx="0.2"/>
-      <rect x="0.7" y="0.6" width="2.2" height="0.7" rx="0.2"/>
-    </g>
-  </g>
-</svg>` },
+  </svg>`
+},
     ];
 
     const langueSelect = document.getElementById("langue-select");


### PR DESCRIPTION
### Motivation
- Align the Spanish (Latin America) label/aria text across the settings UI and i18n definitions to use `Español (Latinoamérica)`.
- Replace the Korean (`KO`) flag artwork with the simplified white background + red/blue taegeuk version (remove black trigrams) for a cleaner, consistent icon.
- Keep language codes and UI keys unchanged while updating only the `LANGS` and `LANGUAGE_CHOICES` blocks.

### Description
- Updated the `ES-LATAM` entry in `parametres.html` to use the requested label `Español (Latinoamérica)` and the provided SVG for the flag.
- Replaced the `KO` block in `parametres.html` with the simplified SVG (white background and red/blue circle, no black trigram paths).
- Updated the `ES-LATAM` object in `js/i18n.js` to set `aria: "Español (Latinoamérica)"` and the provided SVG flag.
- Replaced the `KO` object in `js/i18n.js` with the simplified SVG (white background and red/blue taegeuk) while leaving `code`/`ui` unchanged.

### Testing
- Ran the replacement script which completed successfully and printed `ok` to indicate replacements were applied.
- Verified occurrences with searches (`rg`) to ensure the `ES-LATAM` and `KO` blocks were updated and no old variants remained.
- Inspected the modified file regions with `sed` to confirm the new label/`aria` text and SVG content were inserted as requested; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce4e262e48321a36104795162b02a)