### PR TITLE
Ajuste le header des paramètres et ajoute un style de bouton thème orange sur l’accueil

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,27 @@
     .menu-btn.orange { background: #f0d642  !important; color: #fff !important; box-shadow: 0 3px 15px #2fd7b144; }
     .prix-blanc { color: white; font-size: 0.9em; display: block; margin-top: 5px; }
 
+    .orange-theme-btn {
+      background: linear-gradient(90deg, #ffb86b 0%, #ff9f5a 55%, #ff8a4c 100%);
+      color: #fff;
+      box-shadow: 0 6px 18px rgba(255, 145, 77, 0.28);
+    }
+
+    .orange-theme-btn .btn-label {
+      color: #fff;
+    }
+
+    .orange-theme-btn:hover,
+    .orange-theme-btn:focus-visible {
+      filter: brightness(1.03);
+      transform: translateY(-1px);
+    }
+
+    .orange-theme-btn:active {
+      transform: scale(0.985);
+      filter: brightness(0.98);
+    }
+
     /* Bannière MAJ non bloquante */
     #update-banner {
       position: fixed; left: 16px; right: 16px; bottom: 16px;
@@ -326,7 +347,7 @@
         <span class="info-btn" tabindex="0" data-i18n-tip="tip.boutique" data-tip="Personnalise ton jeu">?</span>
       </button>
 
-      <button class="menu-btn blue" id="btnChangeThemeHome">
+      <button class="menu-btn orange-theme-btn" id="btnChangeThemeHome">
         <span class="btn-label" data-i18n="profil.btn.theme">Changer de thème</span>
       </button>
     </div>

--- a/parametres.html
+++ b/parametres.html
@@ -48,7 +48,7 @@
       align-items: center;
       justify-content: space-between;
       width: 100%;
-      gap: 8px;
+      gap: 4px;
     }
     .btn-back {
       background: none;
@@ -62,17 +62,37 @@
     .btn-back img { width: 28px; height: 28px; filter: drop-shadow(0 1px 2px #0005); }
     .main-title {
       flex: 1;
-      font-size: 2em; font-weight: 900;
+      min-width: 0;
+      font-size: 1.82em;
+      font-weight: 900;
       color: #fff;
-      letter-spacing: 2px; line-height: 1.1;
+      letter-spacing: 1px;
+      line-height: 1.05;
       text-align: center;
-      white-space: pre-line;
-      word-break: break-word;
+      white-space: normal;
+      word-break: normal;
       user-select: none;
       text-shadow: 0 3px 16px #2e6ead44, 0 1px 1px #fff7;
     }
-    .profile-row { display: flex; flex-direction: row; gap: 8px; }
-    .btn-icon img { width: 27px; height: 27px; }
+
+    .profile-row {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 2px;
+      flex-shrink: 0;
+    }
+
+    .profile-row .btn-icon {
+      width: 32px;
+      height: 32px;
+      padding: 2px;
+    }
+
+    .profile-row .btn-icon img {
+      width: 19px;
+      height: 19px;
+    }
     .param-container {
       display: flex;
       flex-direction: column;
@@ -184,13 +204,47 @@
     .music-btn-img { width: 32px; height: 32px; vertical-align: middle; }
     @media (max-width:480px) {
       .main-content, .top-bar { max-width: 100vw; }
+
       .top-bar {
         padding: calc(var(--safe-top) + 4px) 3px 0 3px;
         max-width: 99vw;
       }
-      .main-title { font-size: 1.4em; }
-      .btn-back { width: 32px; height: 32px; }
-      .btn-back img, .btn-icon img { width: 20px; height: 20px; }
+
+      .top-bar-row {
+        gap: 2px;
+      }
+
+      .main-title {
+        font-size: 1.28em;
+        letter-spacing: 0.5px;
+        line-height: 1.02;
+      }
+
+      .btn-back {
+        width: 30px;
+        height: 30px;
+        padding: 2px;
+      }
+
+      .btn-back img {
+        width: 18px;
+        height: 18px;
+      }
+
+      .profile-row {
+        gap: 1px;
+      }
+
+      .profile-row .btn-icon {
+        width: 28px;
+        height: 28px;
+        padding: 1px;
+      }
+
+      .profile-row .btn-icon img {
+        width: 16px;
+        height: 16px;
+      }
     }
     @media (min-width: 768px) {
       .main-content,


### PR DESCRIPTION
### Motivation
- Améliorer l’alignement et réduire les espacements de l’en-tête de la page `parametres.html` pour un rendu plus compact et adapté au mobile.
- Fournir une variante visuelle pour le bouton « Changer de thème » sur la page d’accueil afin d’harmoniser l’UI.

### Description
- Dans `parametres.html` la règle `.top-bar-row` passe de `gap: 8px` à `gap: 4px` pour réduire l’espacement horizontal.
- Le bloc `.main-title` a été remplacé pour inclure `min-width: 0`, `font-size: 1.82em`, `letter-spacing: 1px`, `line-height: 1.05`, `white-space: normal` et `word-break: normal`.
- Les règles de `.profile-row` et `.profile-row .btn-icon` ont été refondues pour alignement, tailles et padding, et le bloc `@media (max-width:480px)` a été mis à jour avec les tailles/gaps mobile demandés.
- Dans `index.html` la classe du bouton `btnChangeThemeHome` a été remplacée de `menu-btn blue` vers `menu-btn orange-theme-btn` et un nouveau bloc CSS `.orange-theme-btn` (avec états `:hover`, `:focus-visible`, `:active` et couleur de `.btn-label`) a été ajouté dans le `<style>`.

### Testing
- Exécuté une recherche source avec `rg` pour confirmer la présence des nouveaux blocs CSS et la substitution de classe (succès).
- Lancé `git diff --check` pour détecter problèmes de format/espaces blancs (succès).
- Inspecté les fichiers modifiés avec `sed`/`nl` pour valider les remplacements dans `parametres.html` et `index.html` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd272745048321b0662a9a1b51dc2a)