### PR TITLE
Queue postgame cross-promo on quit via sessionStorage

### DIFF
--- a/js/crossPromo.js
+++ b/js/crossPromo.js
@@ -632,6 +632,14 @@
     showLowVcoinsPopupNow,
     notifyCompletedRun,
     maybeShowPostGamePromo,
+    queuePostGamePromoForIndex(skipBecauseRewardAd) {
+      try {
+        sessionStorage.setItem("vr_crosspromo_context", "postgame");
+        return true;
+      } catch (_) {
+        return false;
+      }
+    },
     renderCrossPromoPage,
     openStore
   };

--- a/js/game.js
+++ b/js/game.js
@@ -1198,9 +1198,7 @@ overlay.querySelector('#resume-yes').onclick = () => {
 
         try { window.VRCrossPromo?.notifyCompletedRun?.(); } catch (_) {}
         try {
-          await window.VRCrossPromo?.maybeShowPostGamePromo?.({
-            skipBecauseRewardAd: false
-          });
+          window.VRCrossPromo?.queuePostGamePromoForIndex?.(false);
         } catch (_) {}
 
         window.location.href = INDEX_URL;


### PR DESCRIPTION
### Motivation
- Avoid showing the postgame cross-promo immediately when the player quits to the index and instead enqueue the postgame promo context for the index page to handle.

### Description
- Added `queuePostGamePromoForIndex(skipBecauseRewardAd)` to `window.VRCrossPromo` in `js/crossPromo.js`, which stores `vr_crosspromo_context = "postgame"` in `sessionStorage` and returns `true`/`false` depending on storage availability.
- Replaced the immediate call to `maybeShowPostGamePromo` with a call to `window.VRCrossPromo?.queuePostGamePromoForIndex?.(false)` in the `end-quit` handler in `js/game.js` so the promo is queued before redirecting to `INDEX_URL`.
- Left `maybeShowPopupFromContext` unchanged as it already matched the intended behavior.

### Testing
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d583c480832196b992ec993ad8e8)