### PR TITLE
Add referral share popup and invite nudge to endgame flows

### DIFF
--- a/data/AR.json
+++ b/data/AR.json
@@ -296,7 +296,9 @@
   
   "referral.invite_and_earn_title": "ادعُ واربح:",
   "referral.invite_and_earn_btn": "ادعُ واربح",
-  "referral.share_title": "دعوة صديق",
+
+  "referral.share_popup_title": "هل يعجبك VBlocks؟",
+  "referral.share_popup_body": "شاركه مع من حولك، وعرّفهم على اللعبة، واربح VCoins عندما يتم تأكيد الدعوة.",  "referral.share_title": "دعوة صديق",
   "referral.share_text": "حمّل VBlocks من هنا: {url}",
   "referral.link_copied": "تم نسخ الرابط",
   "referral.crosspromo_desc": "ادعُ صديقًا لتثبيت VBlocks واحصل على مكافأة.",

--- a/data/DE.json
+++ b/data/DE.json
@@ -296,7 +296,9 @@
   
   "referral.invite_and_earn_title": "Einladen und verdienen:",
   "referral.invite_and_earn_btn": "Einladen und verdienen",
-  "referral.share_title": "Einen Freund einladen",
+
+  "referral.share_popup_title": "Gefällt dir VBlocks?",
+  "referral.share_popup_body": "Teile es mit deinen Freunden, lass sie das Spiel entdecken und verdiene VCoins, wenn eine Einladung bestätigt wird.",  "referral.share_title": "Einen Freund einladen",
   "referral.share_text": "Lade VBlocks hier herunter: {url}",
   "referral.link_copied": "Link kopiert",
   "referral.crosspromo_desc": "Lade einen Freund ein, VBlocks zu installieren, und erhalte eine Belohnung.",

--- a/data/EN.json
+++ b/data/EN.json
@@ -296,7 +296,9 @@
   
   "referral.invite_and_earn_title": "Invite and earn:",
   "referral.invite_and_earn_btn": "Invite and earn",
-  "referral.share_title": "Invite a friend",
+
+  "referral.share_popup_title": "Enjoying VBlocks?",
+  "referral.share_popup_body": "Share it with people close to you, help them discover the game and earn VCoins when an invite is validated.",  "referral.share_title": "Invite a friend",
   "referral.share_text": "Download VBlocks here: {url}",
   "referral.link_copied": "Link copied",
   "referral.crosspromo_desc": "Invite a friend to install VBlocks and earn a reward.",

--- a/data/ES-LATAM.json
+++ b/data/ES-LATAM.json
@@ -292,7 +292,9 @@
   "crosspromo.apps.vchronicles.popup3.body": "Prueba VChronicles y recibe tu recompensa en VBlocks.",
   "referral.invite_and_earn_title": "Invita y gana:",
   "referral.invite_and_earn_btn": "Invita y gana",
-  "referral.share_title": "Invitar a un amigo",
+
+  "referral.share_popup_title": "¿Te está gustando VBlocks?",
+  "referral.share_popup_body": "Compártelo con tus amigos, haz que descubran el juego y gana VCoins cuando una invitación se valide.",  "referral.share_title": "Invitar a un amigo",
   "referral.share_text": "Descarga VBlocks aquí: {url}",
   "referral.link_copied": "Enlace copiado",
   "referral.crosspromo_desc": "Invita a un amigo a instalar VBlocks y gana una recompensa.",

--- a/data/ES.json
+++ b/data/ES.json
@@ -296,7 +296,9 @@
   
   "referral.invite_and_earn_title": "Invita y gana:",
   "referral.invite_and_earn_btn": "Invita y gana",
-  "referral.share_title": "Invitar a un amigo",
+
+  "referral.share_popup_title": "¿Te gusta VBlocks?",
+  "referral.share_popup_body": "Compártelo con tus amigos, haz que descubran el juego y gana VCoins cuando una invitación se valide.",  "referral.share_title": "Invitar a un amigo",
   "referral.share_text": "Descarga VBlocks aquí: {url}",
   "referral.link_copied": "Enlace copiado",
   "referral.crosspromo_desc": "Invita a un amigo a instalar VBlocks y gana una recompensa.",

--- a/data/FR.json
+++ b/data/FR.json
@@ -296,7 +296,9 @@
   
   "referral.invite_and_earn_title": "Inviter et gagner :",
   "referral.invite_and_earn_btn": "Inviter et gagner",
-  "referral.share_title": "Inviter un ami",
+
+  "referral.share_popup_title": "Tu aimes VBlocks ?",
+  "referral.share_popup_body": "Partage-le avec tes proches, fais découvrir le jeu et gagne des VCoins quand une invitation est validée.",  "referral.share_title": "Inviter un ami",
   "referral.share_text": "Télécharge VBlocks ici : {url}",
   "referral.link_copied": "Lien copié",
   "referral.crosspromo_desc": "Invite un ami à installer VBlocks et gagne une récompense.",

--- a/data/IDN.json
+++ b/data/IDN.json
@@ -296,7 +296,9 @@
   
   "referral.invite_and_earn_title": "Undang dan dapatkan:",
   "referral.invite_and_earn_btn": "Undang dan dapatkan",
-  "referral.share_title": "Undang teman",
+
+  "referral.share_popup_title": "Suka VBlocks?",
+  "referral.share_popup_body": "Bagikan ke orang-orang terdekatmu, kenalkan game ini, dan dapatkan VCoins saat undangan tervalidasi.",  "referral.share_title": "Undang teman",
   "referral.share_text": "Unduh VBlocks di sini: {url}",
   "referral.link_copied": "Tautan disalin",
   "referral.crosspromo_desc": "Undang teman untuk menginstal VBlocks dan dapatkan hadiah.",

--- a/data/IT.json
+++ b/data/IT.json
@@ -296,7 +296,9 @@
   
   "referral.invite_and_earn_title": "Invita e guadagna:",
   "referral.invite_and_earn_btn": "Invita e guadagna",
-  "referral.share_title": "Invita un amico",
+
+  "referral.share_popup_title": "Ti piace VBlocks?",
+  "referral.share_popup_body": "Condividilo con le persone vicine a te, fagli scoprire il gioco e guadagna VCoins quando un invito viene convalidato.",  "referral.share_title": "Invita un amico",
   "referral.share_text": "Scarica VBlocks qui: {url}",
   "referral.link_copied": "Link copiato",
   "referral.crosspromo_desc": "Invita un amico a installare VBlocks e guadagna una ricompensa.",

--- a/data/JP.json
+++ b/data/JP.json
@@ -296,7 +296,9 @@
   
   "referral.invite_and_earn_title": "招待して獲得:",
   "referral.invite_and_earn_btn": "招待して獲得",
-  "referral.share_title": "友だちを招待",
+
+  "referral.share_popup_title": "VBlocks は気に入っていますか？",
+  "referral.share_popup_body": "身近な人にシェアしてゲームを知ってもらい、招待が確認されると VCoins を獲得できます。",  "referral.share_title": "友だちを招待",
   "referral.share_text": "ここから VBlocks をダウンロード: {url}",
   "referral.link_copied": "リンクをコピーしました",
   "referral.crosspromo_desc": "友だちを VBlocks のインストールに招待して、報酬を獲得しよう。",

--- a/data/KO.json
+++ b/data/KO.json
@@ -296,7 +296,9 @@
   
   "referral.invite_and_earn_title": "초대하고 보상 받기:",
   "referral.invite_and_earn_btn": "초대하고 보상 받기",
-  "referral.share_title": "친구 초대",
+
+  "referral.share_popup_title": "VBlocks가 마음에 드나요?",
+  "referral.share_popup_body": "주변 사람들에게 공유해 게임을 알려 주고, 초대가 확인되면 VCoins를 받으세요.",  "referral.share_title": "친구 초대",
   "referral.share_text": "여기에서 VBlocks 다운로드: {url}",
   "referral.link_copied": "링크가 복사되었습니다",
   "referral.crosspromo_desc": "친구를 VBlocks 설치에 초대하고 보상을 받으세요.",

--- a/data/NL.json
+++ b/data/NL.json
@@ -296,7 +296,9 @@
   
   "referral.invite_and_earn_title": "Nodig uit en verdien:",
   "referral.invite_and_earn_btn": "Nodig uit en verdien",
-  "referral.share_title": "Nodig een vriend uit",
+
+  "referral.share_popup_title": "Vind je VBlocks leuk?",
+  "referral.share_popup_body": "Deel het met mensen om je heen, laat ze het spel ontdekken en verdien VCoins wanneer een uitnodiging wordt gevalideerd.",  "referral.share_title": "Nodig een vriend uit",
   "referral.share_text": "Download VBlocks hier: {url}",
   "referral.link_copied": "Link gekopieerd",
   "referral.crosspromo_desc": "Nodig een vriend uit om VBlocks te installeren en verdien een beloning.",

--- a/data/PT-BR.json
+++ b/data/PT-BR.json
@@ -296,7 +296,9 @@
   
   "referral.invite_and_earn_title": "Convide e ganhe:",
   "referral.invite_and_earn_btn": "Convide e ganhe",
-  "referral.share_title": "Convidar um amigo",
+
+  "referral.share_popup_title": "Gostando do VBlocks?",
+  "referral.share_popup_body": "Compartilhe com pessoas próximas, apresente o jogo e ganhe VCoins quando um convite for validado.",  "referral.share_title": "Convidar um amigo",
   "referral.share_text": "Baixe VBlocks aqui: {url}",
   "referral.link_copied": "Link copiado",
   "referral.crosspromo_desc": "Convide um amigo para instalar o VBlocks e ganhe uma recompensa.",

--- a/data/PT.json
+++ b/data/PT.json
@@ -296,7 +296,9 @@
   
   "referral.invite_and_earn_title": "Convida e ganha:",
   "referral.invite_and_earn_btn": "Convida e ganha",
-  "referral.share_title": "Convidar um amigo",
+
+  "referral.share_popup_title": "Gostas do VBlocks?",
+  "referral.share_popup_body": "Partilha-o com as pessoas próximas de ti, dá-lhes a descobrir o jogo e ganha VCoins quando um convite for validado.",  "referral.share_title": "Convidar um amigo",
   "referral.share_text": "Descarrega o VBlocks aqui: {url}",
   "referral.link_copied": "Ligação copiada",
   "referral.crosspromo_desc": "Convida um amigo a instalar o VBlocks e ganha uma recompensa.",

--- a/js/concours.js
+++ b/js/concours.js
@@ -157,6 +157,154 @@ function fillRectThemeSafe(c, px, py, size) {
       shouldShowDuelNudgeThisRun = false;
     }
 
+
+    const REFERRAL_SHARE_POPUP_STATE_KEY = 'vblocks_referral_share_popup_v1';
+    const REFERRAL_SHARE_POPUP_MIN_COMPLETED_RUNS = 12;
+    const REFERRAL_SHARE_POPUP_MIN_MS = 3 * 24 * 60 * 60 * 1000;
+
+    function readReferralSharePopupState() {
+      try {
+        const parsed = JSON.parse(localStorage.getItem(REFERRAL_SHARE_POPUP_STATE_KEY) || '{}');
+        return {
+          completedRuns: Math.max(0, Number(parsed.completedRuns || 0) || 0),
+          lastShownRun: Math.max(0, Number(parsed.lastShownRun || 0) || 0),
+          lastShownAt: Math.max(0, Number(parsed.lastShownAt || 0) || 0)
+        };
+      } catch (_) {
+        return { completedRuns: 0, lastShownRun: 0, lastShownAt: 0 };
+      }
+    }
+
+    function writeReferralSharePopupState(state) {
+      try {
+        localStorage.setItem(REFERRAL_SHARE_POPUP_STATE_KEY, JSON.stringify({
+          completedRuns: Math.max(0, Number(state?.completedRuns || 0) || 0),
+          lastShownRun: Math.max(0, Number(state?.lastShownRun || 0) || 0),
+          lastShownAt: Math.max(0, Number(state?.lastShownAt || 0) || 0)
+        }));
+      } catch (_) {}
+    }
+
+    function registerReferralCompletedRun() {
+      const state = readReferralSharePopupState();
+      state.completedRuns += 1;
+      writeReferralSharePopupState(state);
+      return state;
+    }
+
+    function canShowReferralSharePopup(state) {
+      const st = state || readReferralSharePopupState();
+      if (!st.lastShownRun && !st.lastShownAt) return true;
+
+      const enoughRuns =
+        (Math.max(0, Number(st.completedRuns || 0) || 0) - Math.max(0, Number(st.lastShownRun || 0) || 0)) >= REFERRAL_SHARE_POPUP_MIN_COMPLETED_RUNS;
+      const enoughTime =
+        (Date.now() - Math.max(0, Number(st.lastShownAt || 0) || 0)) >= REFERRAL_SHARE_POPUP_MIN_MS;
+
+      return enoughRuns && enoughTime;
+    }
+
+    function markReferralSharePopupShown(state) {
+      const st = state || readReferralSharePopupState();
+      st.lastShownRun = Math.max(0, Number(st.completedRuns || 0) || 0);
+      st.lastShownAt = Date.now();
+      writeReferralSharePopupState(st);
+      return st;
+    }
+
+    function showReferralSharePopup() {
+      return new Promise((resolve) => {
+        let root = document.getElementById('vr-referral-share-popup');
+        const inviteRewardAmount = Number(window.REFERRAL_INVITE_VCOINS || 200);
+
+        if (!root) {
+          root = document.createElement('div');
+          root.id = 'vr-referral-share-popup';
+          root.style.cssText = [
+            'position:fixed',
+            'inset:0',
+            'z-index:100220',
+            'display:none',
+            'align-items:center',
+            'justify-content:center',
+            'padding:18px',
+            'background:rgba(0,0,0,.62)',
+            'backdrop-filter:blur(8px)'
+          ].join(';');
+
+          root.innerHTML = `
+            <div role="dialog" aria-modal="true" style="position:relative;width:min(430px,92vw);border-radius:22px;padding:20px 18px;background:linear-gradient(180deg, rgba(36,55,117,.98), rgba(28,35,76,.98));border:1px solid rgba(255,255,255,.14);box-shadow:0 18px 42px rgba(0,0,0,.32);color:#fff;">
+              <button id="vr-referral-share-popup-close" type="button" style="position:absolute;top:12px;right:12px;width:38px;height:38px;border:none;border-radius:999px;background:rgba(255,255,255,.14);color:#fff;font-size:18px;font-weight:900;cursor:pointer;">×</button>
+              <div id="vr-referral-share-popup-title" style="font-size:22px;line-height:1.15;font-weight:900;margin-bottom:10px;"></div>
+              <div id="vr-referral-share-popup-body" style="font-size:14px;line-height:1.5;color:rgba(255,255,255,.94);margin-bottom:14px;"></div>
+              <div style="display:flex;align-items:center;gap:8px;margin-bottom:16px;padding:10px 12px;border-radius:14px;border:1px solid rgba(255,255,255,.14);background:rgba(255,255,255,.08);width:max-content;max-width:100%;flex-wrap:wrap;">
+                <span style="font-size:13px;font-weight:900;">${tt('referral.invite_and_earn_title','Inviter et gagner :')}</span>
+                <img src="assets/images/vcoin.webp" alt="" style="width:24px;height:24px;object-fit:contain;" />
+                <span style="font-size:13px;font-weight:900;">+${inviteRewardAmount}</span>
+              </div>
+              <div style="display:grid;grid-template-columns:1fr;gap:10px;">
+                <button id="vr-referral-share-popup-main" type="button" style="min-height:50px;border:none;border-radius:16px;background:linear-gradient(90deg,#7fbeff 0%,#63dcfb 100%);color:#fff;font-weight:800;cursor:pointer;">
+                  ${tt('referral.invite_and_earn_btn','Inviter et gagner')}
+                </button>
+                <button id="vr-referral-share-popup-later" type="button" style="min-height:48px;border:none;border-radius:16px;background:rgba(255,255,255,.15);color:#fff;font-weight:800;cursor:pointer;">
+                  ${tt('common.later','Plus tard')}
+                </button>
+              </div>
+            </div>
+          `;
+
+          document.body.appendChild(root);
+        }
+
+        const titleEl = document.getElementById('vr-referral-share-popup-title');
+        const bodyEl = document.getElementById('vr-referral-share-popup-body');
+        const closeBtn = document.getElementById('vr-referral-share-popup-close');
+        const mainBtn = document.getElementById('vr-referral-share-popup-main');
+        const laterBtn = document.getElementById('vr-referral-share-popup-later');
+
+        if (titleEl) titleEl.textContent = tt('referral.share_popup_title', 'Tu aimes VBlocks ?');
+        if (bodyEl) bodyEl.textContent = tt('referral.share_popup_body', 'Partage-le avec tes proches, fais découvrir le jeu et gagne des VCoins quand une invitation est validée.');
+
+        const close = () => {
+          root.style.display = 'none';
+          root.onclick = null;
+          if (closeBtn) closeBtn.onclick = null;
+          if (mainBtn) mainBtn.onclick = null;
+          if (laterBtn) laterBtn.onclick = null;
+          document.removeEventListener('keydown', onKeyDown);
+          resolve(true);
+        };
+
+        const onKeyDown = (e) => {
+          if (e.key === 'Escape') close();
+        };
+
+        root.onclick = (e) => {
+          if (e.target === root) close();
+        };
+        if (closeBtn) closeBtn.onclick = close;
+        if (laterBtn) laterBtn.onclick = close;
+        if (mainBtn) {
+          mainBtn.onclick = async () => {
+            try { await window.VReferral?.shareInvite?.(); } catch (_) {}
+            close();
+          };
+        }
+
+        root.style.display = 'flex';
+        document.addEventListener('keydown', onKeyDown);
+        setTimeout(() => mainBtn?.focus?.(), 0);
+      });
+    }
+
+    async function maybeShowReferralSharePopupAfterCompletedRun() {
+      const state = readReferralSharePopupState();
+      if (!canShowReferralSharePopup(state)) return false;
+      markReferralSharePopupShown(state);
+      await showReferralSharePopup();
+      return true;
+    }
+
     // Séquence commune (persistance et rewind)
     let piecesSequence = null;
     let piecesUsed = 0;
@@ -755,6 +903,7 @@ function fillRectThemeSafe(c, px, py, size) {
       `;
 
       const rewardAmount = Number(window.REWARD_VCOINS || 300);
+      const referralRewardAmount = Number(window.REFERRAL_INVITE_VCOINS || 200);
       if (!recordBeatAlreadyCountedThisRun && points > (Number(runStartHighscore) || 0)) {
         recordBeatAlreadyCountedThisRun = true;
         const recordBeatCount = getNextRecordBeatCount();
@@ -776,9 +925,38 @@ function fillRectThemeSafe(c, px, py, size) {
           </div>
 
           ${shouldShowDuelNudgeThisRun ? `
-            <div style="margin:0 0 14px 0;padding:12px 14px;border-radius:14px;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.10);line-height:1.45;">
-              <div style="font-weight:800;margin-bottom:4px;">${tt('end.super_score_title','Super score !')}</div>
-              <div style="opacity:.96;">${tt('end.super_score_body','Tu devrais affronter tes amis en Duel pour leur montrer ce que tu vaux.')}</div>
+            <div style="margin:0 0 14px 0;display:flex;flex-direction:column;gap:10px;">
+              <div style="padding:12px 14px;border-radius:14px;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.10);line-height:1.45;">
+                <div style="font-weight:800;margin-bottom:4px;">${tt('end.super_score_title','Super score !')}</div>
+                <div style="opacity:.96;">${tt('end.super_score_body','Tu devrais affronter tes amis en Duel pour leur montrer ce que tu vaux.')}</div>
+              </div>
+
+              <button
+                id="end-invite-friend"
+                type="button"
+                style="
+                  width:100%;
+                  padding:12px 14px;
+                  border:none;
+                  border-radius:14px;
+                  background:linear-gradient(180deg, rgba(126,195,255,.22), rgba(84,133,255,.18));
+                  border:1px solid rgba(126,195,255,.38);
+                  color:#fff;
+                  cursor:pointer;
+                  text-align:left;
+                  box-shadow:0 0 0 rgba(112,183,255,0);
+                "
+              >
+                <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;">
+                  <div style="display:flex;align-items:center;gap:10px;font-weight:900;">
+                    <span>${tt('referral.invite_and_earn_title','Inviter et gagner :')}</span>
+                    <img src="assets/images/vcoin.webp" alt="" style="width:22px;height:22px;object-fit:contain;">
+                    <span>+${referralRewardAmount}</span>
+                  </div>
+                  <span style="padding:7px 12px;border-radius:999px;background:rgba(255,255,255,.14);font-weight:800;white-space:nowrap;">${tt('referral.invite_and_earn_btn','Inviter et gagner')}</span>
+                </div>
+                <div style="margin-top:8px;opacity:.96;line-height:1.45;">${tt('referral.crosspromo_desc','Invite un ami à installer VBlocks et gagne une récompense.')}</div>
+              </button>
             </div>
           ` : ''}
 
@@ -1073,12 +1251,20 @@ function fillRectThemeSafe(c, px, py, size) {
         await commitEndRewards(points);
         endHandled = true;
 
+        const referralState = registerReferralCompletedRun();
+        let referralPopupShown = false;
+        if (shouldShowDuelNudgeThisRun) {
+          referralPopupShown = await maybeShowReferralSharePopupAfterCompletedRun(referralState).catch(() => false);
+        }
+
         try { window.VRCrossPromo?.notifyCompletedRun?.(); } catch (_) {}
-        try {
-          await window.VRCrossPromo?.maybeShowPostGamePromo?.({
-            skipBecauseRewardAd: false
-          });
-        } catch (_) {}
+        if (!referralPopupShown) {
+          try {
+            await window.VRCrossPromo?.maybeShowPostGamePromo?.({
+              skipBecauseRewardAd: false
+            });
+          } catch (_) {}
+        }
 
         popup.remove();
         restartGameHard();
@@ -1088,18 +1274,27 @@ function fillRectThemeSafe(c, px, py, size) {
         await commitEndRewards(points);
         endHandled = true;
 
+        const referralState = registerReferralCompletedRun();
+        let referralPopupShown = false;
+        if (shouldShowDuelNudgeThisRun) {
+          referralPopupShown = await maybeShowReferralSharePopupAfterCompletedRun(referralState).catch(() => false);
+        }
+
         try { window.VRCrossPromo?.notifyCompletedRun?.(); } catch (_) {}
-        try {
-          await window.VRCrossPromo?.maybeShowPostGamePromo?.({
-            skipBecauseRewardAd: false
-          });
-        } catch (_) {}
+        if (!referralPopupShown) {
+          try {
+            await window.VRCrossPromo?.maybeShowPostGamePromo?.({
+              skipBecauseRewardAd: false
+            });
+          } catch (_) {}
+        }
 
         window.location.href = INDEX_URL;
       };
       const btnTok = document.getElementById('end-revive-token');
       const btnAd = document.getElementById('end-revive-ad');
       const btnReward = document.getElementById('end-reward-vcoins');
+      const btnInvite = document.getElementById('end-invite-friend');
       if (btnReward?.animate) {
         btnReward.animate(
           [
@@ -1115,8 +1310,28 @@ function fillRectThemeSafe(c, px, py, size) {
         );
       }
 
+      if (btnInvite?.animate) {
+        btnInvite.animate(
+          [
+            { transform: 'scale(1)', boxShadow: '0 0 0 rgba(112,183,255,0)' },
+            { transform: 'scale(1.025)', boxShadow: '0 0 22px rgba(112,183,255,.42)' },
+            { transform: 'scale(1)', boxShadow: '0 0 0 rgba(112,183,255,0)' }
+          ],
+          {
+            duration: 1500,
+            iterations: Infinity,
+            easing: 'ease-in-out'
+          }
+        );
+      }
+
       if (btnTok) btnTok.onclick = function () { doRevive(false); };
       if (btnAd) btnAd.onclick = function () { doRevive(true); };
+      if (btnInvite) {
+        btnInvite.onclick = async function () {
+          try { await window.VReferral?.shareInvite?.(); } catch (_) {}
+        };
+      }
 
       if (btnReward) {
         btnReward.onclick = async function () {

--- a/js/game.js
+++ b/js/game.js
@@ -157,6 +157,154 @@ function fillRectThemeSafe(c, px, py, size) {
       shouldShowDuelNudgeThisRun = false;
     }
 
+
+    const REFERRAL_SHARE_POPUP_STATE_KEY = 'vblocks_referral_share_popup_v1';
+    const REFERRAL_SHARE_POPUP_MIN_COMPLETED_RUNS = 12;
+    const REFERRAL_SHARE_POPUP_MIN_MS = 3 * 24 * 60 * 60 * 1000;
+
+    function readReferralSharePopupState() {
+      try {
+        const parsed = JSON.parse(localStorage.getItem(REFERRAL_SHARE_POPUP_STATE_KEY) || '{}');
+        return {
+          completedRuns: Math.max(0, Number(parsed.completedRuns || 0) || 0),
+          lastShownRun: Math.max(0, Number(parsed.lastShownRun || 0) || 0),
+          lastShownAt: Math.max(0, Number(parsed.lastShownAt || 0) || 0)
+        };
+      } catch (_) {
+        return { completedRuns: 0, lastShownRun: 0, lastShownAt: 0 };
+      }
+    }
+
+    function writeReferralSharePopupState(state) {
+      try {
+        localStorage.setItem(REFERRAL_SHARE_POPUP_STATE_KEY, JSON.stringify({
+          completedRuns: Math.max(0, Number(state?.completedRuns || 0) || 0),
+          lastShownRun: Math.max(0, Number(state?.lastShownRun || 0) || 0),
+          lastShownAt: Math.max(0, Number(state?.lastShownAt || 0) || 0)
+        }));
+      } catch (_) {}
+    }
+
+    function registerReferralCompletedRun() {
+      const state = readReferralSharePopupState();
+      state.completedRuns += 1;
+      writeReferralSharePopupState(state);
+      return state;
+    }
+
+    function canShowReferralSharePopup(state) {
+      const st = state || readReferralSharePopupState();
+      if (!st.lastShownRun && !st.lastShownAt) return true;
+
+      const enoughRuns =
+        (Math.max(0, Number(st.completedRuns || 0) || 0) - Math.max(0, Number(st.lastShownRun || 0) || 0)) >= REFERRAL_SHARE_POPUP_MIN_COMPLETED_RUNS;
+      const enoughTime =
+        (Date.now() - Math.max(0, Number(st.lastShownAt || 0) || 0)) >= REFERRAL_SHARE_POPUP_MIN_MS;
+
+      return enoughRuns && enoughTime;
+    }
+
+    function markReferralSharePopupShown(state) {
+      const st = state || readReferralSharePopupState();
+      st.lastShownRun = Math.max(0, Number(st.completedRuns || 0) || 0);
+      st.lastShownAt = Date.now();
+      writeReferralSharePopupState(st);
+      return st;
+    }
+
+    function showReferralSharePopup() {
+      return new Promise((resolve) => {
+        let root = document.getElementById('vr-referral-share-popup');
+        const inviteRewardAmount = Number(window.REFERRAL_INVITE_VCOINS || 200);
+
+        if (!root) {
+          root = document.createElement('div');
+          root.id = 'vr-referral-share-popup';
+          root.style.cssText = [
+            'position:fixed',
+            'inset:0',
+            'z-index:100220',
+            'display:none',
+            'align-items:center',
+            'justify-content:center',
+            'padding:18px',
+            'background:rgba(0,0,0,.62)',
+            'backdrop-filter:blur(8px)'
+          ].join(';');
+
+          root.innerHTML = `
+            <div role="dialog" aria-modal="true" style="position:relative;width:min(430px,92vw);border-radius:22px;padding:20px 18px;background:linear-gradient(180deg, rgba(36,55,117,.98), rgba(28,35,76,.98));border:1px solid rgba(255,255,255,.14);box-shadow:0 18px 42px rgba(0,0,0,.32);color:#fff;">
+              <button id="vr-referral-share-popup-close" type="button" style="position:absolute;top:12px;right:12px;width:38px;height:38px;border:none;border-radius:999px;background:rgba(255,255,255,.14);color:#fff;font-size:18px;font-weight:900;cursor:pointer;">×</button>
+              <div id="vr-referral-share-popup-title" style="font-size:22px;line-height:1.15;font-weight:900;margin-bottom:10px;"></div>
+              <div id="vr-referral-share-popup-body" style="font-size:14px;line-height:1.5;color:rgba(255,255,255,.94);margin-bottom:14px;"></div>
+              <div style="display:flex;align-items:center;gap:8px;margin-bottom:16px;padding:10px 12px;border-radius:14px;border:1px solid rgba(255,255,255,.14);background:rgba(255,255,255,.08);width:max-content;max-width:100%;flex-wrap:wrap;">
+                <span style="font-size:13px;font-weight:900;">${tt('referral.invite_and_earn_title','Inviter et gagner :')}</span>
+                <img src="assets/images/vcoin.webp" alt="" style="width:24px;height:24px;object-fit:contain;" />
+                <span style="font-size:13px;font-weight:900;">+${inviteRewardAmount}</span>
+              </div>
+              <div style="display:grid;grid-template-columns:1fr;gap:10px;">
+                <button id="vr-referral-share-popup-main" type="button" style="min-height:50px;border:none;border-radius:16px;background:linear-gradient(90deg,#7fbeff 0%,#63dcfb 100%);color:#fff;font-weight:800;cursor:pointer;">
+                  ${tt('referral.invite_and_earn_btn','Inviter et gagner')}
+                </button>
+                <button id="vr-referral-share-popup-later" type="button" style="min-height:48px;border:none;border-radius:16px;background:rgba(255,255,255,.15);color:#fff;font-weight:800;cursor:pointer;">
+                  ${tt('common.later','Plus tard')}
+                </button>
+              </div>
+            </div>
+          `;
+
+          document.body.appendChild(root);
+        }
+
+        const titleEl = document.getElementById('vr-referral-share-popup-title');
+        const bodyEl = document.getElementById('vr-referral-share-popup-body');
+        const closeBtn = document.getElementById('vr-referral-share-popup-close');
+        const mainBtn = document.getElementById('vr-referral-share-popup-main');
+        const laterBtn = document.getElementById('vr-referral-share-popup-later');
+
+        if (titleEl) titleEl.textContent = tt('referral.share_popup_title', 'Tu aimes VBlocks ?');
+        if (bodyEl) bodyEl.textContent = tt('referral.share_popup_body', 'Partage-le avec tes proches, fais découvrir le jeu et gagne des VCoins quand une invitation est validée.');
+
+        const close = () => {
+          root.style.display = 'none';
+          root.onclick = null;
+          if (closeBtn) closeBtn.onclick = null;
+          if (mainBtn) mainBtn.onclick = null;
+          if (laterBtn) laterBtn.onclick = null;
+          document.removeEventListener('keydown', onKeyDown);
+          resolve(true);
+        };
+
+        const onKeyDown = (e) => {
+          if (e.key === 'Escape') close();
+        };
+
+        root.onclick = (e) => {
+          if (e.target === root) close();
+        };
+        if (closeBtn) closeBtn.onclick = close;
+        if (laterBtn) laterBtn.onclick = close;
+        if (mainBtn) {
+          mainBtn.onclick = async () => {
+            try { await window.VReferral?.shareInvite?.(); } catch (_) {}
+            close();
+          };
+        }
+
+        root.style.display = 'flex';
+        document.addEventListener('keydown', onKeyDown);
+        setTimeout(() => mainBtn?.focus?.(), 0);
+      });
+    }
+
+    async function maybeShowReferralSharePopupAfterCompletedRun() {
+      const state = readReferralSharePopupState();
+      if (!canShowReferralSharePopup(state)) return false;
+      markReferralSharePopupShown(state);
+      await showReferralSharePopup();
+      return true;
+    }
+
     // Séquence commune (persistance et rewind)
     let piecesSequence = null;
     let piecesUsed = 0;
@@ -905,6 +1053,7 @@ overlay.querySelector('#resume-yes').onclick = () => {
         background: rgba(0,0,0,0.55); display:flex; align-items:center; justify-content:center;
       `;
       const rewardAmount = Number(window.REWARD_VCOINS || 300);
+      const referralRewardAmount = Number(window.REFERRAL_INVITE_VCOINS || 200);
       if (!recordBeatAlreadyCountedThisRun && points > (Number(runStartHighscore) || 0)) {
         recordBeatAlreadyCountedThisRun = true;
         const recordBeatCount = getNextRecordBeatCount();
@@ -926,9 +1075,38 @@ overlay.querySelector('#resume-yes').onclick = () => {
           </div>
 
           ${shouldShowDuelNudgeThisRun ? `
-            <div style="margin:0 0 14px 0;padding:12px 14px;border-radius:14px;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.10);line-height:1.45;">
-              <div style="font-weight:800;margin-bottom:4px;">${tt('end.super_score_title','Super score !')}</div>
-              <div style="opacity:.96;">${tt('end.super_score_body','Tu devrais affronter tes amis en Duel pour leur montrer ce que tu vaux.')}</div>
+            <div style="margin:0 0 14px 0;display:flex;flex-direction:column;gap:10px;">
+              <div style="padding:12px 14px;border-radius:14px;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.10);line-height:1.45;">
+                <div style="font-weight:800;margin-bottom:4px;">${tt('end.super_score_title','Super score !')}</div>
+                <div style="opacity:.96;">${tt('end.super_score_body','Tu devrais affronter tes amis en Duel pour leur montrer ce que tu vaux.')}</div>
+              </div>
+
+              <button
+                id="end-invite-friend"
+                type="button"
+                style="
+                  width:100%;
+                  padding:12px 14px;
+                  border:none;
+                  border-radius:14px;
+                  background:linear-gradient(180deg, rgba(126,195,255,.22), rgba(84,133,255,.18));
+                  border:1px solid rgba(126,195,255,.38);
+                  color:#fff;
+                  cursor:pointer;
+                  text-align:left;
+                  box-shadow:0 0 0 rgba(112,183,255,0);
+                "
+              >
+                <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;">
+                  <div style="display:flex;align-items:center;gap:10px;font-weight:900;">
+                    <span>${tt('referral.invite_and_earn_title','Inviter et gagner :')}</span>
+                    <img src="assets/images/vcoin.webp" alt="" style="width:22px;height:22px;object-fit:contain;">
+                    <span>+${referralRewardAmount}</span>
+                  </div>
+                  <span style="padding:7px 12px;border-radius:999px;background:rgba(255,255,255,.14);font-weight:800;white-space:nowrap;">${tt('referral.invite_and_earn_btn','Inviter et gagner')}</span>
+                </div>
+                <div style="margin-top:8px;opacity:.96;line-height:1.45;">${tt('referral.crosspromo_desc','Invite un ami à installer VBlocks et gagne une récompense.')}</div>
+              </button>
             </div>
           ` : ''}
 
@@ -1181,12 +1359,20 @@ overlay.querySelector('#resume-yes').onclick = () => {
         await commitEndRewards(points);
         endHandled = true;
 
+        const referralState = registerReferralCompletedRun();
+        let referralPopupShown = false;
+        if (shouldShowDuelNudgeThisRun) {
+          referralPopupShown = await maybeShowReferralSharePopupAfterCompletedRun(referralState).catch(() => false);
+        }
+
         try { window.VRCrossPromo?.notifyCompletedRun?.(); } catch (_) {}
-        try {
-          await window.VRCrossPromo?.maybeShowPostGamePromo?.({
-            skipBecauseRewardAd: false
-          });
-        } catch (_) {}
+        if (!referralPopupShown) {
+          try {
+            await window.VRCrossPromo?.maybeShowPostGamePromo?.({
+              skipBecauseRewardAd: false
+            });
+          } catch (_) {}
+        }
 
         popup.remove();
         restartGameHard();
@@ -1196,16 +1382,25 @@ overlay.querySelector('#resume-yes').onclick = () => {
         await commitEndRewards(points);
         endHandled = true;
 
+        const referralState = registerReferralCompletedRun();
+        let referralPopupShown = false;
+        if (shouldShowDuelNudgeThisRun) {
+          referralPopupShown = await maybeShowReferralSharePopupAfterCompletedRun(referralState).catch(() => false);
+        }
+
         try { window.VRCrossPromo?.notifyCompletedRun?.(); } catch (_) {}
-        try {
-          window.VRCrossPromo?.queuePostGamePromoForIndex?.(false);
-        } catch (_) {}
+        if (!referralPopupShown) {
+          try {
+            window.VRCrossPromo?.queuePostGamePromoForIndex?.(false);
+          } catch (_) {}
+        }
 
         window.location.href = INDEX_URL;
       };
       const btnTok = document.getElementById('end-revive-token');
       const btnAd = document.getElementById('end-revive-ad');
       const btnReward = document.getElementById('end-reward-vcoins');
+      const btnInvite = document.getElementById('end-invite-friend');
       if (btnReward?.animate) {
         btnReward.animate(
           [
@@ -1221,8 +1416,28 @@ overlay.querySelector('#resume-yes').onclick = () => {
         );
       }
 
+      if (btnInvite?.animate) {
+        btnInvite.animate(
+          [
+            { transform: 'scale(1)', boxShadow: '0 0 0 rgba(112,183,255,0)' },
+            { transform: 'scale(1.025)', boxShadow: '0 0 22px rgba(112,183,255,.42)' },
+            { transform: 'scale(1)', boxShadow: '0 0 0 rgba(112,183,255,0)' }
+          ],
+          {
+            duration: 1500,
+            iterations: Infinity,
+            easing: 'ease-in-out'
+          }
+        );
+      }
+
       if (btnTok) btnTok.onclick = function () { doRevive(false); };
       if (btnAd) btnAd.onclick = function () { doRevive(true); };
+      if (btnInvite) {
+        btnInvite.onclick = async function () {
+          try { await window.VReferral?.shareInvite?.(); } catch (_) {}
+        };
+      }
 
       if (btnReward) {
         btnReward.onclick = async function () {


### PR DESCRIPTION
### Motivation
- Surface a referral/invite flow after completed runs to increase invites and conversions when players hit notable scores. 
- Replace the simple "Super score" nudge with a richer invite cartridge and make the invite action discoverable and animated.

### Description
- Added referral popup state management and helpers (`REFERRAL_SHARE_POPUP_*`, `readReferralSharePopupState`, `writeReferralSharePopupState`, `registerReferralCompletedRun`, `canShowReferralSharePopup`, `markReferralSharePopupShown`, `showReferralSharePopup`, `maybeShowReferralSharePopupAfterCompletedRun`) into `js/game.js` and `js/concours.js` just after `resetRunRecordNudgeState()`.
- Added `referralRewardAmount = Number(window.REFERRAL_INVITE_VCOINS || 200)` alongside existing reward logic in both endgame popups.
- Replaced the old plain "Super score" nudge with a cartridge that includes an `#end-invite-friend` button showing the referral reward, styled copy, and a CTA pill in both `js/game.js` and `js/concours.js`.
- Wired up `btnInvite` (querying `#end-invite-friend`) with a pulse animation and click handler that calls `window.VReferral?.shareInvite?.()`; added the invite button alongside revive/reward buttons and preserved existing revive/reward behaviors.
- Modified `end-restart` and `end-quit` handlers in both files to `registerReferralCompletedRun()` and to conditionally show the referral share popup (via `maybeShowReferralSharePopupAfterCompletedRun`) before invoking cross-promo flows.
- Added i18n keys `referral.share_popup_title` and `referral.share_popup_body` to all requested locale files under `data/*.json`.
- Files touched: `js/game.js`, `js/concours.js`, and locale files `data/*.json` (EN/FR/DE/ES/ES-LATAM/IT/PT/PT-BR/NL/AR/IDN/JP/KO).

### Testing
- Checked JS syntax with `node --check js/game.js` and `node --check js/concours.js`, both succeeded. 
- Validated all modified JSON files with `jq empty data/*.json`, which succeeded. 
- Basic grep/inspection of inserted identifiers (`REFERRAL_SHARE_POPUP_STATE_KEY`, `referralRewardAmount`, `end-invite-friend`, `maybeShowReferralSharePopupAfterCompletedRun`) confirms presence in both `js/game.js` and `js/concours.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0fa618a54832197cf10616ecc71e9)