### PR TITLE
Add rewind tutorial popup flow and localized strings

### DIFF
--- a/data/AR.json
+++ b/data/AR.json
@@ -307,5 +307,9 @@
   "duel.rematch": "مباراة إعادة",
   "duel.rematch.sent": "تم إرسال طلب الإعادة",
   "duel.rematch.ask": "خصمك يطلب مباراة إعادة. هل تقبل؟",
-  "duel.rematch.error": "تعذر بدء مباراة الإعادة الآن."
+  "duel.rematch.error": "تعذر بدء مباراة الإعادة الآن.",
+  "rewind.tip.title": "جديد: رجوع للخلف",
+  "rewind.tip.body": "يمكنك استخدام هذا الزر للرجوع للخلف أثناء اللعب إذا أردت تصحيح حركة.",
+  "rewind.tip.reward": "نمنحك",
+  "rewind.tip.cta": "فهمت"
 }

--- a/data/DE.json
+++ b/data/DE.json
@@ -307,5 +307,9 @@
   "duel.rematch": "Revanche",
   "duel.rematch.sent": "Revanche-Anfrage gesendet",
   "duel.rematch.ask": "Dein Gegner möchte eine Revanche. Annehmen?",
-  "duel.rematch.error": "Eine Revanche kann im Moment nicht gestartet werden."
+  "duel.rematch.error": "Eine Revanche kann im Moment nicht gestartet werden.",
+  "rewind.tip.title": "Neu: Zurück",
+  "rewind.tip.body": "Mit diesem Button kannst du während der Partie zurückgehen, wenn du einen Zug korrigieren möchtest.",
+  "rewind.tip.reward": "Wir schenken dir",
+  "rewind.tip.cta": "Verstanden"
 }

--- a/data/EN.json
+++ b/data/EN.json
@@ -307,5 +307,9 @@
   "duel.rematch": "Rematch",
   "duel.rematch.sent": "Rematch request sent",
   "duel.rematch.ask": "Your opponent is asking for a rematch. Accept?",
-  "duel.rematch.error": "Unable to start a rematch right now."
+  "duel.rematch.error": "Unable to start a rematch right now.",
+  "rewind.tip.title": "New: rewind",
+  "rewind.tip.body": "You can use this button during the game to go back if you want to fix a move.",
+  "rewind.tip.reward": "We’re giving you",
+  "rewind.tip.cta": "Got it"
 }

--- a/data/ES-LATAM.json
+++ b/data/ES-LATAM.json
@@ -303,5 +303,9 @@
   "duel.rematch": "Revancha",
   "duel.rematch.sent": "Solicitud de revancha enviada",
   "duel.rematch.ask": "Tu rival propone una revancha. ¿La aceptas?",
-  "duel.rematch.error": "No se puede iniciar la revancha por ahora."
+  "duel.rematch.error": "No se puede iniciar la revancha por ahora.",
+  "rewind.tip.title": "Nuevo: retroceder",
+  "rewind.tip.body": "Puedes usar este botón durante la partida para retroceder si quieres corregir una jugada.",
+  "rewind.tip.reward": "Te regalamos",
+  "rewind.tip.cta": "Entendido"
 }

--- a/data/ES.json
+++ b/data/ES.json
@@ -307,5 +307,9 @@
   "duel.rematch": "Revancha",
   "duel.rematch.sent": "Solicitud de revancha enviada",
   "duel.rematch.ask": "Tu rival propone una revancha. ¿Aceptar?",
-  "duel.rematch.error": "No se puede iniciar la revancha por ahora."
+  "duel.rematch.error": "No se puede iniciar la revancha por ahora.",
+  "rewind.tip.title": "Nuevo: volver atrás",
+  "rewind.tip.body": "Puedes usar este botón durante la partida para volver atrás si quieres corregir un movimiento.",
+  "rewind.tip.reward": "Te regalamos",
+  "rewind.tip.cta": "Entendido"
 }

--- a/data/FR.json
+++ b/data/FR.json
@@ -307,5 +307,9 @@
   "duel.rematch": "Revanche",
   "duel.rematch.sent": "Demande de revanche envoyée",
   "duel.rematch.ask": "Ton adversaire propose une revanche. Accepter ?",
-  "duel.rematch.error": "Impossible de lancer la revanche pour le moment."
+  "duel.rematch.error": "Impossible de lancer la revanche pour le moment.",
+  "rewind.tip.title": "Nouveau : retour arrière",
+  "rewind.tip.body": "Tu peux utiliser ce bouton pendant la partie pour revenir en arrière si tu veux corriger un coup.",
+  "rewind.tip.reward": "On t’offre",
+  "rewind.tip.cta": "Compris"
 }

--- a/data/IDN.json
+++ b/data/IDN.json
@@ -307,5 +307,9 @@
   "duel.rematch": "Tanding ulang",
   "duel.rematch.sent": "Permintaan tanding ulang dikirim",
   "duel.rematch.ask": "Lawanmu meminta tanding ulang. Terima?",
-  "duel.rematch.error": "Tidak bisa memulai tanding ulang sekarang."
+  "duel.rematch.error": "Tidak bisa memulai tanding ulang sekarang.",
+  "rewind.tip.title": "Baru: mundur",
+  "rewind.tip.body": "Kamu bisa memakai tombol ini saat permainan untuk mundur jika ingin memperbaiki langkah.",
+  "rewind.tip.reward": "Kami memberimu",
+  "rewind.tip.cta": "Mengerti"
 }

--- a/data/IT.json
+++ b/data/IT.json
@@ -307,5 +307,9 @@
   "duel.rematch": "Rivincita",
   "duel.rematch.sent": "Richiesta di rivincita inviata",
   "duel.rematch.ask": "Il tuo avversario propone una rivincita. Accettare?",
-  "duel.rematch.error": "Impossibile avviare una rivincita al momento."
+  "duel.rematch.error": "Impossibile avviare una rivincita al momento.",
+  "rewind.tip.title": "Novità: indietro",
+  "rewind.tip.body": "Puoi usare questo pulsante durante la partita per tornare indietro se vuoi correggere una mossa.",
+  "rewind.tip.reward": "Ti regaliamo",
+  "rewind.tip.cta": "Capito"
 }

--- a/data/JP.json
+++ b/data/JP.json
@@ -307,5 +307,9 @@
   "duel.rematch": "再戦",
   "duel.rematch.sent": "再戦リクエストを送信しました",
   "duel.rematch.ask": "相手が再戦を希望しています。受けますか？",
-  "duel.rematch.error": "今は再戦を開始できません。"
+  "duel.rematch.error": "今は再戦を開始できません。",
+  "rewind.tip.title": "新機能: 巻き戻し",
+  "rewind.tip.body": "このボタンを使うと、プレイ中に手を修正したいときに少し戻れます。",
+  "rewind.tip.reward": "プレゼント",
+  "rewind.tip.cta": "わかった"
 }

--- a/data/KO.json
+++ b/data/KO.json
@@ -307,5 +307,9 @@
   "duel.rematch": "재대결",
   "duel.rematch.sent": "재대결 요청을 보냈습니다",
   "duel.rematch.ask": "상대가 재대결을 원합니다. 수락할까요?",
-  "duel.rematch.error": "지금은 재대결을 시작할 수 없습니다."
+  "duel.rematch.error": "지금은 재대결을 시작할 수 없습니다.",
+  "rewind.tip.title": "새 기능: 되돌리기",
+  "rewind.tip.body": "이 버튼을 사용하면 플레이 중 실수를 고치고 싶을 때 뒤로 돌아갈 수 있어요.",
+  "rewind.tip.reward": "드려요",
+  "rewind.tip.cta": "알겠어요"
 }

--- a/data/NL.json
+++ b/data/NL.json
@@ -307,5 +307,9 @@
   "duel.rematch": "Rematch",
   "duel.rematch.sent": "Rematch-verzoek verzonden",
   "duel.rematch.ask": "Je tegenstander wil een rematch. Accepteren?",
-  "duel.rematch.error": "Kan nu geen rematch starten."
+  "duel.rematch.error": "Kan nu geen rematch starten.",
+  "rewind.tip.title": "Nieuw: terug",
+  "rewind.tip.body": "Met deze knop kun je tijdens het spel teruggaan als je een zet wilt corrigeren.",
+  "rewind.tip.reward": "Je krijgt van ons",
+  "rewind.tip.cta": "Begrepen"
 }

--- a/data/PT-BR.json
+++ b/data/PT-BR.json
@@ -307,5 +307,9 @@
   "duel.rematch": "Revanche",
   "duel.rematch.sent": "Pedido de revanche enviado",
   "duel.rematch.ask": "Seu adversário quer revanche. Aceitar?",
-  "duel.rematch.error": "Não foi possível iniciar a revanche agora."
+  "duel.rematch.error": "Não foi possível iniciar a revanche agora.",
+  "rewind.tip.title": "Novo: voltar",
+  "rewind.tip.body": "Você pode usar este botão durante a partida para voltar se quiser corrigir uma jogada.",
+  "rewind.tip.reward": "A gente te dá",
+  "rewind.tip.cta": "Entendi"
 }

--- a/data/PT.json
+++ b/data/PT.json
@@ -307,5 +307,9 @@
   "duel.rematch": "Revanche",
   "duel.rematch.sent": "Pedido de revanche enviado",
   "duel.rematch.ask": "O teu adversário quer revanche. Aceitas?",
-  "duel.rematch.error": "Não foi possível iniciar a revanche agora."
+  "duel.rematch.error": "Não foi possível iniciar a revanche agora.",
+  "rewind.tip.title": "Novo: voltar atrás",
+  "rewind.tip.body": "Podes usar este botão durante a partida para voltar atrás se quiseres corrigir uma jogada.",
+  "rewind.tip.reward": "Oferecemos-te",
+  "rewind.tip.cta": "Percebi"
 }

--- a/js/game.js
+++ b/js/game.js
@@ -161,6 +161,8 @@ function fillRectThemeSafe(c, px, py, size) {
     const REFERRAL_SHARE_POPUP_STATE_KEY = 'vblocks_referral_share_popup_v1';
     const REFERRAL_SHARE_POPUP_MIN_COMPLETED_RUNS = 12;
     const REFERRAL_SHARE_POPUP_MIN_MS = 3 * 24 * 60 * 60 * 1000;
+    const REWIND_TUTORIAL_STATE_KEY = 'vblocks_rewind_tutorial_v1';
+    const REWIND_TUTORIAL_MIN_PLACED_PIECES = 3;
 
     function readReferralSharePopupState() {
       try {
@@ -303,6 +305,15 @@ function fillRectThemeSafe(c, px, py, size) {
       markReferralSharePopupShown(state);
       await showReferralSharePopup();
       return true;
+    }
+
+    function hasSeenRewindTutorial() {
+      try { return localStorage.getItem(REWIND_TUTORIAL_STATE_KEY) === '1'; }
+      catch (_) { return false; }
+    }
+
+    function markRewindTutorialSeen() {
+      try { localStorage.setItem(REWIND_TUTORIAL_STATE_KEY, '1'); } catch (_) {}
     }
 
     // Séquence commune (persistance et rewind)
@@ -674,6 +685,9 @@ function fillRectThemeSafe(c, px, py, size) {
     let combo = 0;
     let linesCleared = 0;
     let history = [];
+    let piecesLockedThisRun = 0;
+    let rewindTutorialShownThisRun = false;
+    let rewindTutorialBusy = false;
 
     // revive ramp
     let reviveRampActive = false;
@@ -698,7 +712,8 @@ function fillRectThemeSafe(c, px, py, size) {
         heldPiece: heldPiece ? JSON.parse(JSON.stringify(heldPiece)) : null,
         score, combo, linesCleared, dropInterval,
         piecesSequence: piecesSequence ? piecesSequence.slice() : null,
-        piecesUsed
+        piecesUsed,
+        piecesLockedThisRun
       });
       if (history.length > 30) history.shift();
     }
@@ -789,7 +804,8 @@ function fillRectThemeSafe(c, px, py, size) {
         ts: Date.now(),
         inProgress: !gameOver && !!currentPiece, // flag clé → pas de popup si false
         piecesSequence,
-        piecesUsed
+        piecesUsed,
+        piecesLockedThisRun
       };
     }
     function clearSavedGame() {
@@ -860,6 +876,9 @@ function fillRectThemeSafe(c, px, py, size) {
         }
         if (Number.isInteger(s.piecesUsed)) {
           piecesUsed = s.piecesUsed;
+        }
+        if (Number.isInteger(s.piecesLockedThisRun)) {
+          piecesLockedThisRun = Math.max(0, s.piecesLockedThisRun);
         }
 
     // Préfère TOUJOURS le thème actuel choisi par l’utilisateur
@@ -977,6 +996,9 @@ overlay.querySelector('#resume-yes').onclick = () => {
       endHandled = false;
       creditDone = false;
       resetRunRecordNudgeState();
+      piecesLockedThisRun = 0;
+      rewindTutorialShownThisRun = false;
+      rewindTutorialBusy = false;
 
       // UI
       const scoreEl = document.getElementById('score');
@@ -1672,6 +1694,91 @@ function showRewindConfirmPopup() {
   });
 }
 
+async function maybeShowRewindTutorialPopup() {
+  if (mode === 'duel') return;
+  if (piecesLockedThisRun < REWIND_TUTORIAL_MIN_PLACED_PIECES) return;
+  if (rewindTutorialShownThisRun || rewindTutorialBusy) return;
+  if (hasSeenRewindTutorial()) return;
+
+  rewindTutorialBusy = true;
+  rewindTutorialShownThisRun = true;
+
+  try {
+    await userData.addJetons?.(1);
+    markRewindTutorialSeen();
+
+    try {
+      const jetons = await userData.getJetons?.();
+      const j = document.getElementById('header-jetons') || document.getElementById('jetonsCount');
+      if (j && jetons != null) j.textContent = String(jetons);
+    } catch (_) {}
+
+    const oldPopup = document.getElementById('rewind-tutorial-popup');
+    if (oldPopup) oldPopup.remove();
+
+    const wasPaused = paused;
+    paused = true;
+    stopSoftDrop();
+    stopHorizontalRepeat();
+    safeRedraw();
+
+    const popup = document.createElement('div');
+    popup.id = 'rewind-tutorial-popup';
+    popup.style = `
+      position: fixed;
+      inset: 0;
+      z-index: 100001;
+      background: rgba(0,0,0,.45);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 16px;
+    `;
+
+    popup.innerHTML = `
+      <div style="width:min(92vw,360px);background:#23294a;border-radius:18px;padding:18px 16px;box-shadow:0 0 18px rgba(0,0,0,.35);text-align:center;">
+        <div style="display:flex;align-items:center;justify-content:center;gap:10px;margin-bottom:12px;">
+          <img src="assets/icons/rewind_5.svg" alt="" style="width:44px;height:44px;object-fit:contain;filter:drop-shadow(0 2px 8px rgba(0,0,0,.25));">
+          <div style="font-size:1.05em;font-weight:800;line-height:1.2;">${tt('rewind.tip.title','Nouveau : retour arrière')}</div>
+        </div>
+
+        <div style="opacity:.96;line-height:1.5;margin-bottom:10px;">
+          ${tt('rewind.tip.body','Tu peux utiliser ce bouton pendant la partie pour revenir en arrière si tu veux corriger un coup.')}
+        </div>
+
+        <div style="display:flex;align-items:center;justify-content:center;gap:8px;margin-bottom:14px;font-weight:800;">
+          <span>${tt('rewind.tip.reward','On t\'offre')}</span>
+          <img src="assets/images/jeton.webp" alt="" style="width:24px;height:24px;object-fit:contain;">
+          <span>+1</span>
+        </div>
+
+        <button id="rewind-tutorial-ok" style="padding:.78em 1.15em;border:none;border-radius:.85em;background:#39f;color:#fff;cursor:pointer;font-weight:800;">
+          ${tt('rewind.tip.cta','Compris')}
+        </button>
+      </div>
+    `;
+
+    document.body.appendChild(popup);
+
+    const closePopup = () => {
+      popup.remove();
+      paused = wasPaused;
+      safeRedraw();
+      if (!paused && !gameOver) requestAnimationFrame(update);
+    };
+
+    popup.querySelector('#rewind-tutorial-ok')?.addEventListener('click', closePopup);
+    popup.addEventListener('click', (e) => {
+      if (e.target === popup) closePopup();
+    });
+  } catch (e) {
+    rewindTutorialShownThisRun = false;
+    console.warn('[VBlocks] rewind tutorial popup failed', e);
+  } finally {
+    rewindTutorialBusy = false;
+  }
+}
+
 function showNoJetonPopup(opts = {}) {
   const oldMini = document.getElementById('no-jeton-popup');
   if (oldMini) oldMini.remove();
@@ -2003,6 +2110,8 @@ if (score > highscoreCloud) {
 
         merge();
         saveHistory();
+        piecesLockedThisRun += 1;
+        setTimeout(() => { maybeShowRewindTutorialPopup(); }, 120);
         reset();
         if (collision()) {
           showEndPopup(score);
@@ -2116,6 +2225,8 @@ if (score > highscoreCloud) {
       stopSoftDrop();
       merge();
       saveHistory();
+      piecesLockedThisRun += 1;
+      setTimeout(() => { maybeShowRewindTutorialPopup(); }, 120);
       reset();
       lastTime = performance.now();
       if (collision()) {


### PR DESCRIPTION
### Motivation
- Introduce an in-game rewind tutorial that awards one jeton and explains the rewind feature after the player has placed a few pieces.
- Persist and restore the counter used to decide when to show the tutorial so it survives saves/resumes.
- Ensure the tutorial only shows once per user and resets appropriately when restarting a run.

### Description
- Add constants `REWIND_TUTORIAL_STATE_KEY` and `REWIND_TUTORIAL_MIN_PLACED_PIECES` and localStorage helpers `hasSeenRewindTutorial()` and `markRewindTutorialSeen()` in `js/game.js`.
- Track runtime state with `piecesLockedThisRun`, `rewindTutorialShownThisRun`, and `rewindTutorialBusy`, and persist `piecesLockedThisRun` in `saveHistory()` and `getSavableState()`, restore it in `restoreFromSave()` and reset it in `restartGameHard()`.
- Implement `maybeShowRewindTutorialPopup()` which pauses the game, awards `+1` jeton via `userData.addJetons`, updates the jeton counter in the header, records that the tutorial was seen, and shows a localized modal; trigger it after piece lock in both `dropPiece()` and `hardDrop()` (with a small `setTimeout`).
- Add the four i18n keys `rewind.tip.title`, `rewind.tip.body`, `rewind.tip.reward`, and `rewind.tip.cta` to all requested locale files under `data/`.

### Testing
- Ran a JSON parse check via `python` to validate all `data/*.json` files parse successfully (result: succeeded).
- Verified the presence of new identifiers and placements in `js/game.js` using search and inspected the diff to confirm requested block replacements were applied (result: matches changes described).
- Reviewed the generated diff/stat to ensure the i18n keys were added to each locale file and the code edits are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e105abc80c8321b6e89a7e85b1b1ea)