### PR TITLE
Update referral index-share prompt state keys and frequency controls

### DIFF
--- a/js/referral.js
+++ b/js/referral.js
@@ -6,10 +6,11 @@
   const PENDING_RAW_KEY = "vblocks_install_referrer_pending_raw_v1";
 
   const INVITE_BASE_URL = "https://hystvblod.github.io/vblocks-invite/invite.html";
-  const INDEX_SHARE_PROMPT_STATE_KEY = "vblocks_referral_index_share_state_v1";
-  const INDEX_SHARE_PROMPT_QUEUE_KEY = "vblocks_referral_index_share_queue_v1";
+  const INDEX_SHARE_PROMPT_STATE_KEY = "vblocks_referral_index_share_state_v2";
+  const INDEX_SHARE_PROMPT_QUEUE_KEY = "vblocks_referral_index_share_queue_v2";
   const INDEX_SHARE_PROMPT_MIN_RUNS = 12;
   const INDEX_SHARE_PROMPT_MIN_MS = 3 * 24 * 60 * 60 * 1000;
+  const INDEX_SHARE_PROMPT_MAX_SHOWS = 2;
 
   function t(key, fallback) {
     try {
@@ -206,13 +207,15 @@
       return {
         completedRuns: Math.max(0, Number(parsed.completedRuns || 0) || 0),
         lastShownRun: Math.max(0, Number(parsed.lastShownRun || 0) || 0),
-        lastShownAt: Math.max(0, Number(parsed.lastShownAt || 0) || 0)
+        lastShownAt: Math.max(0, Number(parsed.lastShownAt || 0) || 0),
+        shownCount: Math.max(0, Number(parsed.shownCount || 0) || 0)
       };
     } catch (_) {
       return {
         completedRuns: 0,
         lastShownRun: 0,
-        lastShownAt: 0
+        lastShownAt: 0,
+        shownCount: 0
       };
     }
   }
@@ -222,7 +225,8 @@
       localStorage.setItem(INDEX_SHARE_PROMPT_STATE_KEY, JSON.stringify({
         completedRuns: Math.max(0, Number(state?.completedRuns || 0) || 0),
         lastShownRun: Math.max(0, Number(state?.lastShownRun || 0) || 0),
-        lastShownAt: Math.max(0, Number(state?.lastShownAt || 0) || 0)
+        lastShownAt: Math.max(0, Number(state?.lastShownAt || 0) || 0),
+        shownCount: Math.max(0, Number(state?.shownCount || 0) || 0)
       }));
     } catch (_) {}
   }
@@ -236,6 +240,7 @@
 
   function canShowIndexSharePrompt(state) {
     const st = state || readIndexSharePromptState();
+    if (Math.max(0, Number(st.shownCount || 0) || 0) >= INDEX_SHARE_PROMPT_MAX_SHOWS) return false;
     if (!st.lastShownRun && !st.lastShownAt) return true;
 
     const enoughRuns =
@@ -258,6 +263,7 @@
     const state = readIndexSharePromptState();
     state.lastShownRun = Math.max(0, Number(state.completedRuns || 0) || 0);
     state.lastShownAt = Date.now();
+    state.shownCount = Math.max(0, Number(state.shownCount || 0) || 0) + 1;
     writeIndexSharePromptState(state);
     return state;
   }


### PR DESCRIPTION
### Motivation
- Limit and version the index-page referral share prompt so it can be queued/shown controllably and avoid over-showing to users.

### Description
- Bumped storage keys from `v1` to `v2` (`INDEX_SHARE_PROMPT_STATE_KEY` and `INDEX_SHARE_PROMPT_QUEUE_KEY`) and added `INDEX_SHARE_PROMPT_MAX_SHOWS = 2` in `js/referral.js`.
- Extended persisted prompt state with `shownCount` and wired read/write defaults and serialization for that field.
- Enforced the max-show count in `canShowIndexSharePrompt` and incremented `shownCount` in `markIndexSharePromptShown`.

### Testing
- Ran `node --check js/referral.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e114b3aa7c8321b03cebdad5c40960)