### PR TITLE
Add rewind tutorial constants to classic game initialization

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -146,6 +146,8 @@ function fillRectThemeSafe(c, px, py, size) {
     const duelId = opts?.duelId || null;
     const duelPlayerNum = opts?.duelPlayerNum || 1;
     const RECORD_BEAT_COUNT_KEY = 'vblocks_record_beats_classic_v1';
+    const REWIND_TUTORIAL_STATE_KEY = 'vblocks_rewind_tutorial_v1';
+    const REWIND_TUTORIAL_MIN_PLACED_PIECES = 8;
 
     let runStartHighscore = 0;
     let recordBeatAlreadyCountedThisRun = false;


### PR DESCRIPTION
### Motivation
- Introduce persistent keys and a placement threshold for the rewind tutorial so the classic game mode can track whether the tutorial has been shown and when to trigger it.

### Description
- Add `REWIND_TUTORIAL_STATE_KEY = 'vblocks_rewind_tutorial_v1'` and `REWIND_TUTORIAL_MIN_PLACED_PIECES = 8` next to the existing `RECORD_BEAT_COUNT_KEY` in `js/game.js` inside `initGame`.

### Testing
- No automated tests were run for this constants-only change; the file was added and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e11a4726308321b957fecc363e1c58)