### PR TITLE
Update referral popup layout, add invite CTA i18n and button pulse

### DIFF
--- a/data/AR.json
+++ b/data/AR.json
@@ -292,6 +292,7 @@
   "crosspromo.apps.vchronicles.popup3.body": "جرّب VChronicles واحصل على مكافأتك في VBlocks.",
   "referral.invite_and_earn_title": "ادعُ واربح:",
   "referral.invite_and_earn_btn": "ادعُ واربح",
+  "referral.invite_btn": "ادعُ",
   "referral.share_popup_title": "هل يعجبك VBlocks؟",
   "referral.share_popup_body": "شاركه مع من حولك، وعرّفهم على اللعبة، واربح VCoins عندما يتم تأكيد الدعوة.",
   "referral.share_title": "دعوة صديق",

--- a/data/DE.json
+++ b/data/DE.json
@@ -292,6 +292,7 @@
   "crosspromo.apps.vchronicles.popup3.body": "Probiere VChronicles aus und hole dir deine Belohnung in VBlocks.",
   "referral.invite_and_earn_title": "Einladen und verdienen:",
   "referral.invite_and_earn_btn": "Einladen und verdienen",
+  "referral.invite_btn": "Einladen",
   "referral.share_popup_title": "Gefällt dir VBlocks?",
   "referral.share_popup_body": "Teile es mit deinen Freunden, lass sie das Spiel entdecken und verdiene VCoins, wenn eine Einladung bestätigt wird.",
   "referral.share_title": "Einen Freund einladen",

--- a/data/EN.json
+++ b/data/EN.json
@@ -292,6 +292,7 @@
   "crosspromo.apps.vchronicles.popup3.body": "Try VChronicles and collect your reward on VBlocks.",
   "referral.invite_and_earn_title": "Invite and earn:",
   "referral.invite_and_earn_btn": "Invite and earn",
+  "referral.invite_btn": "Invite",
   "referral.share_popup_title": "Enjoying VBlocks?",
   "referral.share_popup_body": "Share it with people close to you, help them discover the game and earn VCoins when an invite is validated.",
   "referral.share_title": "Invite a friend",

--- a/data/ES-LATAM.json
+++ b/data/ES-LATAM.json
@@ -292,6 +292,7 @@
   "crosspromo.apps.vchronicles.popup3.body": "Prueba VChronicles y recibe tu recompensa en VBlocks.",
   "referral.invite_and_earn_title": "Invita y gana:",
   "referral.invite_and_earn_btn": "Invita y gana",
+  "referral.invite_btn": "Invitar",
   "referral.share_popup_title": "¿Te está gustando VBlocks?",
   "referral.share_popup_body": "Compártelo con tus amigos, haz que descubran el juego y gana VCoins cuando una invitación se valide.",
   "referral.share_title": "Invitar a un amigo",

--- a/data/ES.json
+++ b/data/ES.json
@@ -292,6 +292,7 @@
   "crosspromo.apps.vchronicles.popup3.body": "Prueba VChronicles y recibe tu recompensa en VBlocks.",
   "referral.invite_and_earn_title": "Invita y gana:",
   "referral.invite_and_earn_btn": "Invita y gana",
+  "referral.invite_btn": "Invitar",
   "referral.share_popup_title": "¿Te gusta VBlocks?",
   "referral.share_popup_body": "Compártelo con tus amigos, haz que descubran el juego y gana VCoins cuando una invitación se valide.",
   "referral.share_title": "Invitar a un amigo",

--- a/data/FR.json
+++ b/data/FR.json
@@ -292,6 +292,7 @@
   "crosspromo.apps.vchronicles.popup3.body": "Essaie VChronicles et récupère ta récompense sur VBlocks.",
   "referral.invite_and_earn_title": "Inviter et gagner :",
   "referral.invite_and_earn_btn": "Inviter et gagner",
+  "referral.invite_btn": "Inviter",
   "referral.share_popup_title": "Tu aimes VBlocks ?",
   "referral.share_popup_body": "Partage-le avec tes proches, fais découvrir le jeu et gagne des VCoins quand une invitation est validée.",
   "referral.share_title": "Inviter un ami",

--- a/data/IDN.json
+++ b/data/IDN.json
@@ -292,6 +292,7 @@
   "crosspromo.apps.vchronicles.popup3.body": "Coba VChronicles dan ambil hadiahmu di VBlocks.",
   "referral.invite_and_earn_title": "Undang dan dapatkan:",
   "referral.invite_and_earn_btn": "Undang dan dapatkan",
+  "referral.invite_btn": "Undang",
   "referral.share_popup_title": "Suka VBlocks?",
   "referral.share_popup_body": "Bagikan ke orang-orang terdekatmu, kenalkan game ini, dan dapatkan VCoins saat undangan tervalidasi.",
   "referral.share_title": "Undang teman",

--- a/data/IT.json
+++ b/data/IT.json
@@ -292,6 +292,7 @@
   "crosspromo.apps.vchronicles.popup3.body": "Prova VChronicles e ricevi la tua ricompensa su VBlocks.",
   "referral.invite_and_earn_title": "Invita e guadagna:",
   "referral.invite_and_earn_btn": "Invita e guadagna",
+  "referral.invite_btn": "Invita",
   "referral.share_popup_title": "Ti piace VBlocks?",
   "referral.share_popup_body": "Condividilo con le persone vicine a te, fagli scoprire il gioco e guadagna VCoins quando un invito viene convalidato.",
   "referral.share_title": "Invita un amico",

--- a/data/JP.json
+++ b/data/JP.json
@@ -292,6 +292,7 @@
   "crosspromo.apps.vchronicles.popup3.body": "VChronicles を試して、VBlocks で報酬を受け取ってください。",
   "referral.invite_and_earn_title": "招待して獲得:",
   "referral.invite_and_earn_btn": "招待して獲得",
+  "referral.invite_btn": "招待する",
   "referral.share_popup_title": "VBlocks は気に入っていますか？",
   "referral.share_popup_body": "身近な人にシェアしてゲームを知ってもらい、招待が確認されると VCoins を獲得できます。",
   "referral.share_title": "友だちを招待",

--- a/data/KO.json
+++ b/data/KO.json
@@ -292,6 +292,7 @@
   "crosspromo.apps.vchronicles.popup3.body": "VChronicles를 플레이하고 VBlocks에서 보상을 받으세요.",
   "referral.invite_and_earn_title": "초대하고 보상 받기:",
   "referral.invite_and_earn_btn": "초대하고 보상 받기",
+  "referral.invite_btn": "초대하기",
   "referral.share_popup_title": "VBlocks가 마음에 드나요?",
   "referral.share_popup_body": "주변 사람들에게 공유해 게임을 알려 주고, 초대가 확인되면 VCoins를 받으세요.",
   "referral.share_title": "친구 초대",

--- a/data/NL.json
+++ b/data/NL.json
@@ -292,6 +292,7 @@
   "crosspromo.apps.vchronicles.popup3.body": "Probeer VChronicles en ontvang je beloning in VBlocks.",
   "referral.invite_and_earn_title": "Nodig uit en verdien:",
   "referral.invite_and_earn_btn": "Nodig uit en verdien",
+  "referral.invite_btn": "Uitnodigen",
   "referral.share_popup_title": "Vind je VBlocks leuk?",
   "referral.share_popup_body": "Deel het met mensen om je heen, laat ze het spel ontdekken en verdien VCoins wanneer een uitnodiging wordt gevalideerd.",
   "referral.share_title": "Nodig een vriend uit",

--- a/data/PT-BR.json
+++ b/data/PT-BR.json
@@ -292,6 +292,7 @@
   "crosspromo.apps.vchronicles.popup3.body": "Teste VChronicles e receba sua recompensa no VBlocks.",
   "referral.invite_and_earn_title": "Convide e ganhe:",
   "referral.invite_and_earn_btn": "Convide e ganhe",
+  "referral.invite_btn": "Convidar",
   "referral.share_popup_title": "Gostando do VBlocks?",
   "referral.share_popup_body": "Compartilhe com pessoas próximas, apresente o jogo e ganhe VCoins quando um convite for validado.",
   "referral.share_title": "Convidar um amigo",

--- a/data/PT.json
+++ b/data/PT.json
@@ -292,6 +292,7 @@
   "crosspromo.apps.vchronicles.popup3.body": "Experimenta VChronicles e recebe a tua recompensa no VBlocks.",
   "referral.invite_and_earn_title": "Convida e ganha:",
   "referral.invite_and_earn_btn": "Convida e ganha",
+  "referral.invite_btn": "Convidar",
   "referral.share_popup_title": "Gostas do VBlocks?",
   "referral.share_popup_body": "Partilha-o com as pessoas próximas de ti, dá-lhes a descobrir o jogo e ganha VCoins quando um convite for validado.",
   "referral.share_title": "Convidar um amigo",

--- a/js/referral.js
+++ b/js/referral.js
@@ -271,8 +271,6 @@
   function showIndexSharePromptPopup() {
     return new Promise((resolve) => {
       let root = document.getElementById("vr-referral-index-share-popup");
-      const inviteRewardAmount = Number(window.REFERRAL_INVITE_VCOINS || 200);
-
       if (!root) {
         root = document.createElement("div");
         root.id = "vr-referral-index-share-popup";
@@ -294,16 +292,17 @@
 
             <div id="vr-referral-index-share-popup-title" style="font-size:22px;line-height:1.15;font-weight:900;margin-bottom:10px;text-align:center;padding:0 26px;"></div>
 
-            <div id="vr-referral-index-share-popup-body" style="font-size:14px;line-height:1.5;color:rgba(255,255,255,.94);margin-bottom:12px;text-align:center;"></div>
+            <div id="vr-referral-index-share-popup-body" style="font-size:14px;line-height:1.5;color:rgba(255,255,255,.94);margin-bottom:14px;text-align:center;"></div>
 
-            <div style="display:flex;align-items:center;justify-content:center;gap:8px;margin-bottom:16px;text-align:center;">
-              <img src="assets/images/vcoin.webp" alt="" style="width:20px;height:20px;object-fit:contain;" />
-              <span style="font-size:15px;font-weight:900;">+${inviteRewardAmount}</span>
+            <div style="display:flex;align-items:center;justify-content:center;gap:10px;margin-bottom:16px;text-align:center;flex-wrap:wrap;">
+              <span style="font-size:17px;font-weight:900;">${t("referral.invite_and_earn_btn", "Inviter et gagner")}</span>
+              <img src="assets/images/vcoin.webp" alt="" style="width:22px;height:22px;object-fit:contain;" />
+              <span style="font-size:18px;font-weight:900;">+300</span>
             </div>
 
             <div style="display:grid;grid-template-columns:1fr;gap:10px;">
-              <button id="vr-referral-index-share-popup-main" type="button" style="min-height:52px;border:none;border-radius:16px;background:linear-gradient(90deg,#7fbeff 0%,#63dcfb 100%);color:#fff;font-weight:900;font-size:17px;letter-spacing:.2px;cursor:pointer;box-shadow:0 10px 24px rgba(99,220,251,.28);">
-                ${t("referral.invite_and_earn_btn", "Inviter et gagner")}
+              <button id="vr-referral-index-share-popup-main" type="button" style="min-height:54px;border:none;border-radius:16px;background:linear-gradient(90deg,#7fbeff 0%,#63dcfb 100%);color:#fff;font-weight:900;font-size:18px;letter-spacing:.2px;cursor:pointer;box-shadow:0 10px 24px rgba(99,220,251,.28);">
+                ${t("referral.invite_btn", "Inviter")}
               </button>
               <button id="vr-referral-index-share-popup-later" type="button" style="min-height:48px;border:none;border-radius:16px;background:rgba(255,255,255,.15);color:#fff;font-weight:800;cursor:pointer;">
                 ${t("common.later", "Plus tard")}
@@ -352,6 +351,22 @@
 
       root.style.display = "flex";
       document.addEventListener("keydown", onKeyDown);
+
+      if (mainBtn?.animate) {
+        mainBtn.animate(
+          [
+            { transform: "scale(1)", boxShadow: "0 10px 24px rgba(99,220,251,.28)" },
+            { transform: "scale(1.03)", boxShadow: "0 14px 30px rgba(99,220,251,.42)" },
+            { transform: "scale(1)", boxShadow: "0 10px 24px rgba(99,220,251,.28)" }
+          ],
+          {
+            duration: 1400,
+            iterations: Infinity,
+            easing: "ease-in-out"
+          }
+        );
+      }
+
       setTimeout(() => mainBtn?.focus?.(), 0);
     });
   }


### PR DESCRIPTION
### Motivation
- Make the index referral share popup match the requested centered layout and stronger visual CTA.  
- Ensure the main CTA uses a dedicated i18n key so it can be translated per locale.  
- Add a subtle pulse animation to the primary button to draw attention.

### Description
- Replaced the HTML template inside `showIndexSharePromptPopup()` in `js/referral.js` to render a single centered line with `Inviter et gagner` + VCoin image + `+300`, centered body text, and the two CTAs.  
- Changed the main CTA to use the new i18n key `referral.invite_btn` (fallback: `Inviter`) and adjusted button sizing and typography.  
- Added a pulse animation for the main button using `Element.animate()` when the popup is shown.  
- Added `"referral.invite_btn"` to all locale files under `data/*.json` with the provided translations and removed the unused dynamic `inviteRewardAmount` constant in favor of the static `+300` display.

### Testing
- Verified updated strings exist using ripgrep with `rg 'referral.invite_and_earn_btn|referral.invite_btn' data/*.json`.  
- Validated all modified locale JSON files parse successfully using `node -e "...JSON.parse(...)"`.  
- Confirmed `js/referral.js` contains the new template, the `referral.invite_btn` usage and the `mainBtn.animate` pulse block via `rg` checks; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e159d0a8b08321b86e6047630e7e20)