### PR TITLE
Update referral and cross-promo reward amounts

### DIFF
--- a/cross-promo.html
+++ b/cross-promo.html
@@ -412,7 +412,7 @@
       <div class="cp-pill">
         <span data-i18n="referral.invite_and_earn_title">Inviter et gagner :</span>
         <img src="assets/images/crosspromo/vcoins.webp" alt="" draggable="false" />
-        <span>+ 200</span>
+        <span>+ 500</span>
       </div>
 
       <p class="cp-referral-desc" data-i18n="referral.crosspromo_desc">

--- a/js/concours.js
+++ b/js/concours.js
@@ -758,7 +758,7 @@ function fillRectThemeSafe(c, px, py, size) {
       `;
 
       const rewardAmount = Number(window.REWARD_VCOINS || 300);
-      const referralRewardAmount = Number(window.REFERRAL_INVITE_VCOINS || 300);
+      const referralRewardAmount = Number(window.REFERRAL_INVITE_VCOINS || 500);
       if (!recordBeatAlreadyCountedThisRun && points > (Number(runStartHighscore) || 0)) {
         recordBeatAlreadyCountedThisRun = true;
         const recordBeatCount = getNextRecordBeatCount();

--- a/js/crossPromo.js
+++ b/js/crossPromo.js
@@ -2,7 +2,7 @@
   "use strict";
 
   const STORAGE_KEY = "vblocks_crosspromo_state";
-  const REWARD_AMOUNT = 600;
+  const REWARD_AMOUNT = 1000;
   const POSTGAME_MIN_DELAY_MS = 12 * 60 * 60 * 1000;
   const POSTGAME_FIRST_COMPLETED_RUNS = 4;
   const POSTGAME_AFTER_DISMISS_COMPLETED_RUNS = 6;

--- a/js/game.js
+++ b/js/game.js
@@ -930,7 +930,7 @@ overlay.querySelector('#resume-yes').onclick = () => {
         background: rgba(0,0,0,0.55); display:flex; align-items:center; justify-content:center;
       `;
       const rewardAmount = Number(window.REWARD_VCOINS || 300);
-      const referralRewardAmount = Number(window.REFERRAL_INVITE_VCOINS || 300);
+      const referralRewardAmount = Number(window.REFERRAL_INVITE_VCOINS || 500);
       if (!recordBeatAlreadyCountedThisRun && points > (Number(runStartHighscore) || 0)) {
         recordBeatAlreadyCountedThisRun = true;
         const recordBeatCount = getNextRecordBeatCount();

--- a/js/referral.js
+++ b/js/referral.js
@@ -297,7 +297,7 @@
             <div style="display:flex;align-items:center;justify-content:center;gap:10px;margin-bottom:16px;text-align:center;flex-wrap:wrap;">
               <span style="font-size:17px;font-weight:900;">${t("referral.invite_and_earn_btn", "Inviter et gagner")}</span>
               <img src="assets/images/vcoin.webp" alt="" style="width:22px;height:22px;object-fit:contain;" />
-              <span style="font-size:18px;font-weight:900;">+300</span>
+              <span style="font-size:18px;font-weight:900;">+500</span>
             </div>
 
             <div style="display:grid;grid-template-columns:1fr;gap:10px;">

--- a/profil.html
+++ b/profil.html
@@ -323,7 +323,7 @@
     <div class="vb-referral-pill" style="background:rgba(15,25,48,0.28);border:1px solid rgba(255,255,255,0.12);border-radius:999px;padding:8px 12px;font-weight:900;color:#fff;">
       <span data-i18n="referral.invite_and_earn_title">Inviter et gagner :</span>
       <img src="assets/images/crosspromo/vcoins.webp" alt="" draggable="false" style="width:22px;height:22px;object-fit:contain;display:block;" />
-      <span>+ 200</span>
+      <span>+ 500</span>
     </div>
   </div>
 


### PR DESCRIPTION
### Motivation
- Align displayed referral text and fallback constants with the new higher reward amounts and update the true cross-promo reward constant used by the app.

### Description
- Replace `+ 200` with `+ 500` in `profil.html` and `cross-promo.html`.
- Replace `+300` with `+500` in the referral popup markup in `js/referral.js`.
- Update fallback `REFERRAL_INVITE_VCOINS || 300` to `REFERRAL_INVITE_VCOINS || 500` in `js/game.js` and `js/concours.js`.
- Update `REWARD_AMOUNT` from `600` to `1000` in `js/crossPromo.js`.

### Testing
- Ran the replacement script (`python - <<'PY'`) which reported replacements in all 6 targeted files and exited successfully.
- Verified the updated patterns and absence of legacy values using `rg` across the modified files and observed only the new values.
- Inspected file excerpts with `nl` to confirm the exact lines contain the new values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f1bd5990832196f2d210f6c67fd8)