### PR TITLE
Update referral invite base URL to vboldcompany

### DIFF
--- a/js/referral.js
+++ b/js/referral.js
@@ -5,7 +5,7 @@
   const PENDING_INVITER_KEY = "vblocks_install_referrer_pending_inviter_v1";
   const PENDING_RAW_KEY = "vblocks_install_referrer_pending_raw_v1";
 
-  const INVITE_BASE_URL = "https://hystvblod.github.io/vblocks-invite/invite.html";
+  const INVITE_BASE_URL = "https://vboldcompany.github.io/Vblocks-invite/invite.html";
   const INDEX_SHARE_PROMPT_STATE_KEY = "vblocks_referral_index_share_state_v2";
   const INDEX_SHARE_PROMPT_QUEUE_KEY = "vblocks_referral_index_share_queue_v2";
   const INDEX_SHARE_PROMPT_MIN_RUNS = 12;


### PR DESCRIPTION
### Motivation
- Replace the hardcoded referral invite URL so shared invite links point to the new `vboldcompany` GitHub Pages host.

### Description
- Update the `INVITE_BASE_URL` constant in `js/referral.js` from `https://hystvblod.github.io/vblocks-invite/invite.html` to `https://vboldcompany.github.io/Vblocks-invite/invite.html` and commit the change.

### Testing
- No automated tests were run for this one-line constant update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22cc1ee488321bd2bd3f55f242106)