### PR TITLE
Met à jour la grille à 11x22 et remplace les matrices de pièces dans tous les modes de jeu

### DIFF
--- a/ads.html
+++ b/ads.html
@@ -31,7 +31,7 @@
     .top-canvas-row { width:100%; max-width:410px; display:flex; justify-content:space-between; align-items:flex-end; margin-top:-24px; }
     .side-canvas-block label { color:var(--panel-text); font-weight:700; }
     #holdCanvas,#nextCanvas { background:var(--canvas-panel-bg); border:2px dashed var(--canvas-panel-border); border-radius:8px; }
-    #gameCanvas { width:100%; max-width:330px; aspect-ratio:10/20; background:var(--canvas-bg); border-radius:8px; display:block; margin:0 auto; touch-action:none; }
+    #gameCanvas { width:100%; max-width:330px; aspect-ratio:11/22; background:var(--canvas-bg); border-radius:8px; display:block; margin:0 auto; touch-action:none; }
     .score-row { margin-top:8px; display:flex; gap:1rem; flex-wrap:wrap; justify-content:center; color:var(--score-color); font-weight:700; }
     #controls { display:flex; justify-content:center; gap:10px; margin-top:10px; }
     #controls button, #pause-btn { background:var(--btn-bg); color:var(--btn-color); border:1px solid var(--btn-border); border-radius:12px; padding:10px 14px; font-weight:700; }
@@ -244,7 +244,7 @@ function fillRectThemeSafe(c, px, py, size) {
     const nextCanvas = document.getElementById('nextCanvas');
     const nextCtx = nextCanvas ? nextCanvas.getContext('2d') : null;
 
-    const COLS = 10, ROWS = 20;
+    const COLS = 11, ROWS = 22;
     let BLOCK_SIZE = 30; // en px CSS (pas device)
     const DPR = Math.max(1, Math.floor(window.devicePixelRatio || 1));
 
@@ -459,13 +459,13 @@ function fillRectThemeSafe(c, px, py, size) {
 
 
     const PIECES = [
-      [[1,1,1,1]],
-      [[1,0,0],[1,1,1]],
-      [[0,0,1],[1,1,1]],
-      [[1,1],[1,1]],
-      [[0,1,1],[1,1,0]],
-      [[0,1,0],[1,1,1]],
-      [[1,1,0],[0,1,1]]
+      [[1,1,1,1,1]],                 // I = 5 cases
+      [[1,0,0],[1,1,1]],             // J
+      [[0,0,1],[1,1,1]],             // L
+      [[1,1,1],[1,1,1]],             // O = rectangle 2x3
+      [[0,1,1],[1,1,0]],             // S
+      [[1,1,1],[0,1,0],[0,1,0]],     // T = vrai T en 5 cases
+      [[1,1,0],[0,1,1]]              // Z
     ];
     const LETTERS = ['I','J','L','O','S','T','Z'];
 

--- a/classic.html
+++ b/classic.html
@@ -224,7 +224,7 @@
     #gameCanvas {
       width: 100%;
       max-width: 330px;
-      aspect-ratio: 10/20;
+      aspect-ratio: 11/22;
       height: auto;
       max-height: none;
       background: var(--canvas-bg, #180654);

--- a/concours.html
+++ b/concours.html
@@ -237,7 +237,7 @@
       margin-bottom: 4px;
     }
     #gameCanvas {
-      width: 100%; max-width: 330px; aspect-ratio: 10/20;
+      width: 100%; max-width: 330px; aspect-ratio: 11/22;
       height: auto; max-height: 100%;
       background: var(--canvas-bg, #180654);
       border-radius: 0.4em; box-shadow: 0 6px 32px #39ff1411;

--- a/duel.html
+++ b/duel.html
@@ -177,7 +177,7 @@
       margin-bottom: 4px;
     }
     #gameCanvas {
-      width: 100%; max-width: 330px; aspect-ratio: 10/20;
+      width: 100%; max-width: 330px; aspect-ratio: 11/22;
       height: auto; max-height: 100%;
       background: var(--canvas-bg, #180654);
       border-radius: 0.4em; box-shadow: 0 6px 32px #39ff1411;

--- a/infini.html
+++ b/infini.html
@@ -162,7 +162,7 @@
       margin-bottom: 4px;
     }
     #gameCanvas {
-      width: 100%; max-width: 330px; aspect-ratio: 10/20;
+      width: 100%; max-width: 330px; aspect-ratio: 11/22;
       height: auto; max-height: 100%;
       background: var(--canvas-bg, #180654);
       border-radius: 0.4em; box-shadow: 0 6px 32px #39ff1411;

--- a/js/concours.js
+++ b/js/concours.js
@@ -182,7 +182,7 @@ function fillRectThemeSafe(c, px, py, size) {
     const nextCanvas = document.getElementById('nextCanvas');
     const nextCtx = nextCanvas ? nextCanvas.getContext('2d') : null;
 
-    const COLS = 10, ROWS = 20;
+    const COLS = 11, ROWS = 22;
     let BLOCK_SIZE = 30; // en px CSS (pas device)
     const DPR = Math.max(1, Math.floor(window.devicePixelRatio || 1));
 
@@ -354,13 +354,13 @@ function fillRectThemeSafe(c, px, py, size) {
 
 
     const PIECES = [
-      [[1,1,1,1]],
-      [[1,0,0],[1,1,1]],
-      [[0,0,1],[1,1,1]],
-      [[1,1],[1,1]],
-      [[0,1,1],[1,1,0]],
-      [[0,1,0],[1,1,1]],
-      [[1,1,0],[0,1,1]]
+      [[1,1,1,1,1]],                 // I = 5 cases
+      [[1,0,0],[1,1,1]],             // J
+      [[0,0,1],[1,1,1]],             // L
+      [[1,1,1],[1,1,1]],             // O = rectangle 2x3
+      [[0,1,1],[1,1,0]],             // S
+      [[1,1,1],[0,1,0],[0,1,0]],     // T = vrai T en 5 cases
+      [[1,1,0],[0,1,1]]              // Z
     ];
     const LETTERS = ['I','J','L','O','S','T','Z'];
 

--- a/js/game.js
+++ b/js/game.js
@@ -193,7 +193,7 @@ function fillRectThemeSafe(c, px, py, size) {
     const nextCanvas = document.getElementById('nextCanvas');
     const nextCtx = nextCanvas ? nextCanvas.getContext('2d') : null;
 
-    const COLS = 10, ROWS = 20;
+    const COLS = 11, ROWS = 22;
     let BLOCK_SIZE = 30; // en px CSS (pas device)
     const DPR = Math.max(1, Math.floor(window.devicePixelRatio || 1));
 
@@ -431,13 +431,13 @@ function fillRectThemeSafe(c, px, py, size) {
 
 
     const PIECES = [
-      [[1,1,1,1]],
-      [[1,0,0],[1,1,1]],
-      [[0,0,1],[1,1,1]],
-      [[1,1],[1,1]],
-      [[0,1,1],[1,1,0]],
-      [[0,1,0],[1,1,1]],
-      [[1,1,0],[0,1,1]]
+      [[1,1,1,1,1]],                 // I = 5 cases
+      [[1,0,0],[1,1,1]],             // J
+      [[0,0,1],[1,1,1]],             // L
+      [[1,1,1],[1,1,1]],             // O = rectangle 2x3
+      [[0,1,1],[1,1,0]],             // S
+      [[1,1,1],[0,1,0],[0,1,0]],     // T = vrai T en 5 cases
+      [[1,1,0],[0,1,1]]              // Z
     ];
     const LETTERS = ['I','J','L','O','S','T','Z'];
 

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -146,7 +146,7 @@ function fillRectThemeSafe(c, px, py, size) {
     const nextCtx = nextCanvas ? nextCanvas.getContext('2d') : null;
     const scoreEl = document.getElementById('score');
 
-    const COLS = 10, ROWS = 20;
+    const COLS = 11, ROWS = 22;
     let BLOCK_SIZE = 30; // en px CSS
     const DPR = Math.max(1, Math.floor(window.devicePixelRatio || 1));
     ctx.imageSmoothingEnabled = false;
@@ -345,13 +345,13 @@ function fillRectThemeSafe(c, px, py, size) {
 
     // ====== Pièces ======
     const PIECES = [
-      [[1,1,1,1]],
-      [[1,0,0],[1,1,1]],
-      [[0,0,1],[1,1,1]],
-      [[1,1],[1,1]],
-      [[0,1,1],[1,1,0]],
-      [[0,1,0],[1,1,1]],
-      [[1,1,0],[0,1,1]]
+      [[1,1,1,1,1]],                 // I = 5 cases
+      [[1,0,0],[1,1,1]],             // J
+      [[0,0,1],[1,1,1]],             // L
+      [[1,1,1],[1,1,1]],             // O = rectangle 2x3
+      [[0,1,1],[1,1,0]],             // S
+      [[1,1,1],[0,1,0],[0,1,0]],     // T = vrai T en 5 cases
+      [[1,1,0],[0,1,1]]              // Z
     ];
     const LETTERS = ['I','J','L','O','S','T','Z'];
 


### PR DESCRIPTION
### Motivation
- Harmoniser le moteur de jeu avec de nouvelles dimensions de plateau et de nouvelles formes de pièces demandées (`11x22` et nouveaux matrices de `PIECES`) pour modifier le gameplay global sans toucher aux clés techniques de rendu (`LETTERS`).
- Appliquer les mêmes modifications au mini-moteur présent dans `ads.html` et corriger l’`aspect-ratio` CSS partout pour garder la cohérence visuelle.

### Description
- Remplacé `const COLS = 10, ROWS = 20;` par `const COLS = 11, ROWS = 22;` dans `js/game.js`, `js/game_duel.js`, `js/concours.js` et l’embed de jeu dans `ads.html`.
- Remplacé le bloc `PIECES` par la nouvelle définition (I=5, O=2x3, T vrai T en 5 cases, etc.) dans les mêmes fichiers tout en conservant `const LETTERS = ['I','J','L','O','S','T','Z'];`.
- Mis à jour `aspect-ratio: 10/20;` → `aspect-ratio: 11/22;` dans `classic.html`, `infini.html`, `duel.html`, `concours.html` et `ads.html` pour aligner le CSS sur la nouvelle grille.
- Les modifications ont été ajoutées et commitées sur la branche de travail; les mini-canvases (`sizeMiniCanvas(..., 48)`) n’ont pas été modifiés (optionnel).

### Testing
- Exécuté des recherches `rg` pour vérifier l’absence des anciennes valeurs et la présence des nouveaux blocs (`COLS/ROWS`, `PIECES`, `LETTERS`, `aspect-ratio`) et obtenu des correspondances attendues (succès).
- Le script de remplacement automatique a été exécuté et les fichiers ciblés ont été mis à jour, puis un `git commit` a été réalisé avec succès (8 fichiers modifiés).
- Aucune suite de tests unitaires automatique n’a été exécutée dans cet environnement; seules les vérifications textuelles et le commit ont été effectués et ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2996c73b88321aa4b1f54534459c2)