### PR TITLE
Add U piece and extend single-block theme handling

### DIFF
--- a/ads.html
+++ b/ads.html
@@ -367,7 +367,7 @@ function fillRectThemeSafe(c, px, py, size) {
     function generateSequenceClassic(bags = 200) {
       const res = [];
       for (let b = 0; b < bags; b++) {
-        const bag = [0,1,2,3,4,5,6]; // I,J,L,O,S,T,Z
+        const bag = [0,1,2,3,4,5,6,7]; // I,J,L,O,S,T,Z
         shuffle(bag);
         res.push(...bag);
       }
@@ -396,19 +396,25 @@ function fillRectThemeSafe(c, px, py, size) {
           img.src = (themeName === 'cyber') ? `assetes/${i}.png` : `themes/${themeName}/${i}.png`;
           blockImages[themeName].push(img);
         }
-        ['I','J','L','O','S','T','Z'].forEach(l => { blockImages[l] = null; });
+        ['I','J','L','O','S','T','Z','U'].forEach(l => { blockImages[l] = null; });
       }
-      else if (themeName === 'grece' || themeName === 'arabic') {
+      else if (
+  themeName === 'grece' ||
+  themeName === 'arabic' ||
+  themeName === 'angelique' ||
+  themeName === 'bubble' ||
+  themeName === 'nature'
+) {
         // === UNE SEULE IMAGE POUR TOUTES LES PIÈCES ===
         const img = new Image();
         img.onload  = () => { safeRedraw(); };
         img.onerror = () => {};
         img.src = (themeName === 'cyber') ? `assetes/block.png` : `themes/${themeName}/block.png`;
-        ['I','J','L','O','S','T','Z'].forEach(l => { blockImages[l] = img; });
+        ['I','J','L','O','S','T','Z','U'].forEach(l => { blockImages[l] = img; });
       }
       else {
         // === CAS NORMAL (1 fichier par lettre) ===
-        ['I','J','L','O','S','T','Z'].forEach(l => {
+        ['I','J','L','O','S','T','Z','U'].forEach(l => {
           if (themesWithPNG.includes(themeName)) {
             const img = new Image();
             img.onload  = () => { safeRedraw(); };
@@ -465,9 +471,10 @@ function fillRectThemeSafe(c, px, py, size) {
       [[1,1,1],[1,1,1]],             // O = rectangle 2x3
       [[0,1,1],[1,1,0]],             // S
       [[1,1,1],[0,1,0],[0,1,0]],     // T = vrai T en 5 cases
-      [[1,1,0],[0,1,1]]              // Z
+      [[1,1,0],[0,1,1]],             // Z
+      [[1,1,1],[1,0,1]]              // U = 5 cases
     ];
-    const LETTERS = ['I','J','L','O','S','T','Z'];
+    const LETTERS = ['I','J','L','O','S','T','Z','U'];
 
     function cloneMatrix(shape) {
       if (!Array.isArray(shape)) return null;
@@ -1381,7 +1388,7 @@ window.updateHighScoreDisplay = updateHighscoreDisplay;
       if (mode === 'duel') typeId = getDuelNextPieceId();
       else typeId = getNextPieceIdGeneric();
 
-      if (typeId < 0 || typeId > 6 || Number.isNaN(typeId)) {
+      if (typeId < 0 || typeId > 7 || Number.isNaN(typeId)) {
         typeId = Math.floor(Math.random() * PIECES.length);
       }
 

--- a/js/concours.js
+++ b/js/concours.js
@@ -262,7 +262,7 @@ function fillRectThemeSafe(c, px, py, size) {
     function generateSequenceClassic(bags = 200) {
       const res = [];
       for (let b = 0; b < bags; b++) {
-        const bag = [0,1,2,3,4,5,6]; // I,J,L,O,S,T,Z
+        const bag = [0,1,2,3,4,5,6,7]; // I,J,L,O,S,T,Z
         shuffle(bag);
         res.push(...bag);
       }
@@ -291,19 +291,25 @@ function fillRectThemeSafe(c, px, py, size) {
           img.src = `themes/${themeName}/${i}.png`;
           blockImages[themeName].push(img);
         }
-        ['I','J','L','O','S','T','Z'].forEach(l => { blockImages[l] = null; });
+        ['I','J','L','O','S','T','Z','U'].forEach(l => { blockImages[l] = null; });
       }
-      else if (themeName === 'grece' || themeName === 'arabic') {
+      else if (
+  themeName === 'grece' ||
+  themeName === 'arabic' ||
+  themeName === 'angelique' ||
+  themeName === 'bubble' ||
+  themeName === 'nature'
+) {
         // === UNE SEULE IMAGE POUR TOUTES LES PIÈCES ===
         const img = new Image();
         img.onload  = () => { safeRedraw(); };
         img.onerror = () => {};
         img.src = `themes/${themeName}/block.png`;
-        ['I','J','L','O','S','T','Z'].forEach(l => { blockImages[l] = img; });
+        ['I','J','L','O','S','T','Z','U'].forEach(l => { blockImages[l] = img; });
       }
       else {
         // === CAS NORMAL (1 fichier par lettre) ===
-        ['I','J','L','O','S','T','Z'].forEach(l => {
+        ['I','J','L','O','S','T','Z','U'].forEach(l => {
           if (themesWithPNG.includes(themeName)) {
             const img = new Image();
             img.onload  = () => { safeRedraw(); };
@@ -360,9 +366,10 @@ function fillRectThemeSafe(c, px, py, size) {
       [[1,1,1],[1,1,1]],             // O = rectangle 2x3
       [[0,1,1],[1,1,0]],             // S
       [[1,1,1],[0,1,0],[0,1,0]],     // T = vrai T en 5 cases
-      [[1,1,0],[0,1,1]]              // Z
+      [[1,1,0],[0,1,1]],             // Z
+      [[1,1,1],[1,0,1]]              // U = 5 cases
     ];
-    const LETTERS = ['I','J','L','O','S','T','Z'];
+    const LETTERS = ['I','J','L','O','S','T','Z','U'];
 
     let board = Array.from({ length: ROWS }, () => Array(COLS).fill(''));
 
@@ -1453,7 +1460,7 @@ function fillRectThemeSafe(c, px, py, size) {
       if (mode === 'duel') typeId = getDuelNextPieceId();
       else typeId = getNextPieceIdGeneric();
 
-      if (typeId < 0 || typeId > 6 || Number.isNaN(typeId)) {
+      if (typeId < 0 || typeId > 7 || Number.isNaN(typeId)) {
         typeId = Math.floor(Math.random() * PIECES.length);
       }
 

--- a/js/game.js
+++ b/js/game.js
@@ -339,7 +339,7 @@ function fillRectThemeSafe(c, px, py, size) {
     function generateSequenceClassic(bags = 200) {
       const res = [];
       for (let b = 0; b < bags; b++) {
-        const bag = [0,1,2,3,4,5,6]; // I,J,L,O,S,T,Z
+        const bag = [0,1,2,3,4,5,6,7]; // I,J,L,O,S,T,Z
         shuffle(bag);
         res.push(...bag);
       }
@@ -368,19 +368,25 @@ function fillRectThemeSafe(c, px, py, size) {
           img.src = `themes/${themeName}/${i}.png`;
           blockImages[themeName].push(img);
         }
-        ['I','J','L','O','S','T','Z'].forEach(l => { blockImages[l] = null; });
+        ['I','J','L','O','S','T','Z','U'].forEach(l => { blockImages[l] = null; });
       }
-      else if (themeName === 'grece' || themeName === 'arabic') {
+      else if (
+  themeName === 'grece' ||
+  themeName === 'arabic' ||
+  themeName === 'angelique' ||
+  themeName === 'bubble' ||
+  themeName === 'nature'
+) {
         // === UNE SEULE IMAGE POUR TOUTES LES PIÈCES ===
         const img = new Image();
         img.onload  = () => { safeRedraw(); };
         img.onerror = () => {};
         img.src = `themes/${themeName}/block.png`;
-        ['I','J','L','O','S','T','Z'].forEach(l => { blockImages[l] = img; });
+        ['I','J','L','O','S','T','Z','U'].forEach(l => { blockImages[l] = img; });
       }
       else {
         // === CAS NORMAL (1 fichier par lettre) ===
-        ['I','J','L','O','S','T','Z'].forEach(l => {
+        ['I','J','L','O','S','T','Z','U'].forEach(l => {
           if (themesWithPNG.includes(themeName)) {
             const img = new Image();
             img.onload  = () => { safeRedraw(); };
@@ -437,9 +443,10 @@ function fillRectThemeSafe(c, px, py, size) {
       [[1,1,1],[1,1,1]],             // O = rectangle 2x3
       [[0,1,1],[1,1,0]],             // S
       [[1,1,1],[0,1,0],[0,1,0]],     // T = vrai T en 5 cases
-      [[1,1,0],[0,1,1]]              // Z
+      [[1,1,0],[0,1,1]],             // Z
+      [[1,1,1],[1,0,1]]              // U = 5 cases
     ];
-    const LETTERS = ['I','J','L','O','S','T','Z'];
+    const LETTERS = ['I','J','L','O','S','T','Z','U'];
 
     function cloneMatrix(shape) {
       if (!Array.isArray(shape)) return null;
@@ -1879,7 +1886,7 @@ window.updateHighScoreDisplay = updateHighscoreDisplay;
       if (mode === 'duel') typeId = getDuelNextPieceId();
       else typeId = getNextPieceIdGeneric();
 
-      if (typeId < 0 || typeId > 6 || Number.isNaN(typeId)) {
+      if (typeId < 0 || typeId > 7 || Number.isNaN(typeId)) {
         typeId = Math.floor(Math.random() * PIECES.length);
       }
 

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -289,17 +289,23 @@ function fillRectThemeSafe(c, px, py, size) {
           img.src = `themes/${themeName}/${i}.png`;
           blockImages[themeName].push(img);
         }
-        ['I','J','L','O','S','T','Z'].forEach(l => { blockImages[l] = null; });
-      } else if (themeName === 'grece' || themeName === 'arabic') {
+        ['I','J','L','O','S','T','Z','U'].forEach(l => { blockImages[l] = null; });
+      } else if (
+  themeName === 'grece' ||
+  themeName === 'arabic' ||
+  themeName === 'angelique' ||
+  themeName === 'bubble' ||
+  themeName === 'nature'
+) {
         // Une seule image pour toutes les pièces
         const img = new Image();
         img.onload = () => { safeRedraw(); };
         img.onerror = () => {};
         img.src = `themes/${themeName}/block.png`;
-        ['I','J','L','O','S','T','Z'].forEach(l => { blockImages[l] = img; });
+        ['I','J','L','O','S','T','Z','U'].forEach(l => { blockImages[l] = img; });
       } else {
         // PNG par lettre (ou fallback dessin)
-        ['I','J','L','O','S','T','Z'].forEach(l => {
+        ['I','J','L','O','S','T','Z','U'].forEach(l => {
           if (themesWithPNG.includes(themeName)) {
             const img = new Image();
             img.onload = () => { safeRedraw(); };
@@ -351,9 +357,10 @@ function fillRectThemeSafe(c, px, py, size) {
       [[1,1,1],[1,1,1]],             // O = rectangle 2x3
       [[0,1,1],[1,1,0]],             // S
       [[1,1,1],[0,1,0],[0,1,0]],     // T = vrai T en 5 cases
-      [[1,1,0],[0,1,1]]              // Z
+      [[1,1,0],[0,1,1]],             // Z
+      [[1,1,1],[1,0,1]]              // U = 5 cases
     ];
-    const LETTERS = ['I','J','L','O','S','T','Z'];
+    const LETTERS = ['I','J','L','O','S','T','Z','U'];
 
 
     function cloneMatrix(shape) {
@@ -484,7 +491,7 @@ function fillRectThemeSafe(c, px, py, size) {
     async function setupDuelSequence() {
       if (!duelId || !sb) {
         // fallback solo/random si pas d’ID (démo locale)
-        piecesSequence = Array.from({ length: 1000 }, () => Math.floor(Math.random() * 7));
+        piecesSequence = Array.from({ length: 1000 }, () => Math.floor(Math.random() * 8));
         piecesUsed = 0;
         return;
       }
@@ -782,7 +789,7 @@ function fillRectThemeSafe(c, px, py, size) {
 
     function newPiece() {
       let typeId = getDuelNextPieceId();
-      if (Number.isNaN(typeId) || typeId < 0 || typeId > 6) typeId = 3;
+      if (Number.isNaN(typeId) || typeId < 0 || typeId > 7) typeId = 3;
       const letter = LETTERS[typeId];
       return createSafePiece(letter);
     }


### PR DESCRIPTION
### Motivation
- Introduire la nouvelle pièce `U` dans le jeu et l’intégrer partout où les pièces sont définies ou tirées aléatoirement. 
- Faire en sorte que le moteur d’assets prenne en charge `U` pour les thèmes qui utilisent une image unique ou des PNG par lettre. 

### Description
- Ajout d’un nouvel élément `U` dans `PIECES` (forme 5-cases) et extension de `LETTERS` pour inclure `'U'` dans `js/game.js`, `js/concours.js`, `js/game_duel.js` et `ads.html`.
- Extension des « bags » de pièces de 7 à 8 IDs (`const bag = [0,1,2,3,4,5,6,7];`) et mise à jour de la génération aléatoire de séquences (remplacement de `Math.random() * 7` par `Math.random() * 8` où nécessaire).
- Mise à jour des validations de type pour `typeId` (conditions passant de `> 6` à `> 7`) et adaptation des chemins qui construisent de nouvelles pièces pour tenir compte de `U`.
- Extension du traitement des thèmes qui partagent une seule image de bloc pour couvrir aussi `angelique`, `bubble` et `nature`, et propagation de `U` dans les boucles qui assignent `blockImages`.

### Testing
- Exécution de `git diff --check` sans erreurs signalées. 
- Vérification par recherche (`rg`) qu’il n’existe plus d’occurrences de l’ancienne liste de 7 lettres ou des contrôles `typeId > 6` dans les fichiers ciblés, et que les remplacements attendus sont présents dans `js/game.js`, `js/concours.js`, `js/game_duel.js` et `ads.html`.
- Aucune erreur de syntaxe détectée pendant les opérations de modification automatisée et les fichiers modifiés sont cohérents avec la nouvelle logique (vérifications locales terminées avec succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29eebb9088321abb3dd325ffecb75)