### PR TITLE
Ajuste la largeur du plateau à 12 colonnes

### DIFF
--- a/ads.html
+++ b/ads.html
@@ -244,7 +244,7 @@ function fillRectThemeSafe(c, px, py, size) {
     const nextCanvas = document.getElementById('nextCanvas');
     const nextCtx = nextCanvas ? nextCanvas.getContext('2d') : null;
 
-    const COLS = 11, ROWS = 22;
+    const COLS = 12, ROWS = 22;
     let BLOCK_SIZE = 30; // en px CSS (pas device)
     const DPR = Math.max(1, Math.floor(window.devicePixelRatio || 1));
 

--- a/classic.html
+++ b/classic.html
@@ -224,7 +224,7 @@
     #gameCanvas {
       width: 100%;
       max-width: 330px;
-      aspect-ratio: 11/22;
+      aspect-ratio: 12/22;
       height: auto;
       max-height: none;
       background: var(--canvas-bg, #180654);

--- a/concours.html
+++ b/concours.html
@@ -237,7 +237,7 @@
       margin-bottom: 4px;
     }
     #gameCanvas {
-      width: 100%; max-width: 330px; aspect-ratio: 11/22;
+      width: 100%; max-width: 330px; aspect-ratio: 12/22;
       height: auto; max-height: 100%;
       background: var(--canvas-bg, #180654);
       border-radius: 0.4em; box-shadow: 0 6px 32px #39ff1411;

--- a/duel.html
+++ b/duel.html
@@ -177,7 +177,7 @@
       margin-bottom: 4px;
     }
     #gameCanvas {
-      width: 100%; max-width: 330px; aspect-ratio: 11/22;
+      width: 100%; max-width: 330px; aspect-ratio: 12/22;
       height: auto; max-height: 100%;
       background: var(--canvas-bg, #180654);
       border-radius: 0.4em; box-shadow: 0 6px 32px #39ff1411;

--- a/infini.html
+++ b/infini.html
@@ -162,7 +162,7 @@
       margin-bottom: 4px;
     }
     #gameCanvas {
-      width: 100%; max-width: 330px; aspect-ratio: 11/22;
+      width: 100%; max-width: 330px; aspect-ratio: 12/22;
       height: auto; max-height: 100%;
       background: var(--canvas-bg, #180654);
       border-radius: 0.4em; box-shadow: 0 6px 32px #39ff1411;

--- a/js/concours.js
+++ b/js/concours.js
@@ -182,7 +182,7 @@ function fillRectThemeSafe(c, px, py, size) {
     const nextCanvas = document.getElementById('nextCanvas');
     const nextCtx = nextCanvas ? nextCanvas.getContext('2d') : null;
 
-    const COLS = 11, ROWS = 22;
+    const COLS = 12, ROWS = 22;
     let BLOCK_SIZE = 30; // en px CSS (pas device)
     const DPR = Math.max(1, Math.floor(window.devicePixelRatio || 1));
 

--- a/js/game.js
+++ b/js/game.js
@@ -193,7 +193,7 @@ function fillRectThemeSafe(c, px, py, size) {
     const nextCanvas = document.getElementById('nextCanvas');
     const nextCtx = nextCanvas ? nextCanvas.getContext('2d') : null;
 
-    const COLS = 11, ROWS = 22;
+    const COLS = 12, ROWS = 22;
     let BLOCK_SIZE = 30; // en px CSS (pas device)
     const DPR = Math.max(1, Math.floor(window.devicePixelRatio || 1));
 

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -146,7 +146,7 @@ function fillRectThemeSafe(c, px, py, size) {
     const nextCtx = nextCanvas ? nextCanvas.getContext('2d') : null;
     const scoreEl = document.getElementById('score');
 
-    const COLS = 11, ROWS = 22;
+    const COLS = 12, ROWS = 22;
     let BLOCK_SIZE = 30; // en px CSS
     const DPR = Math.max(1, Math.floor(window.devicePixelRatio || 1));
     ctx.imageSmoothingEnabled = false;


### PR DESCRIPTION
### Motivation
- Étendre la grille de jeu d'origine de 11 à 12 colonnes et synchroniser le ratio d'affichage CSS pour que l'UI reflète la nouvelle largeur.

### Description
- Remplacement de `const COLS = 11, ROWS = 22;` par `const COLS = 12, ROWS = 22;` dans la logique de jeu (`js/game.js`, `js/concours.js`, `js/game_duel.js`, `ads.html`).
- Remplacement de `aspect-ratio: 11/22;` par `aspect-ratio: 12/22;` dans les pages HTML/CSS (`classic.html`, `infini.html`, `duel.html`, `concours.html`).
- Modifications regroupées et validées puis commitées avec le message `Ajuste la grille en 12 colonnes et le ratio d'affichage`.

### Testing
- Exécution de la recherche `rg -n "const COLS = 12, ROWS = 22;|aspect-ratio: 12/22;"` sur les fichiers ciblés pour vérifier les nouvelles occurrences, qui a réussi.
- Exécution de la recherche `rg -n "const COLS = 11, ROWS = 22;|aspect-ratio: 11/22;"` pour vérifier qu'aucune ancienne occurrence ne subsiste, qui a renvoyé aucun résultat.
- `git status --short` puis `git commit` ont été exécutés pour enregistrer les changements avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e73b243dec83219c4df87258353687)