### PR TITLE
Add cordova.js and js/achat.js includes to game pages

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -484,6 +484,8 @@
 <script src="js/referral.js"></script>
 
 <!-- Ads -->
+<script src="cordova.js"></script>
+<script src="js/achat.js"></script>
 <script src="js/pub.js"></script>
 
 <!-- Jeu -->

--- a/concours.html
+++ b/concours.html
@@ -465,6 +465,9 @@
   <script src="js/crossPromo.js"></script>
   <script src="js/referral.js"></script>
   <!-- Ads -->
+
+  <script src="cordova.js"></script>
+  <script src="js/achat.js"></script>
   <script src="js/pub.js"></script>
   <!-- Jeu (gère les scores concours + "score à battre") -->
   <script src="js/concours.js"></script>

--- a/infini.html
+++ b/infini.html
@@ -405,6 +405,8 @@
 <script src="js/crossPromo.js"></script>
 
 <!-- Ads -->
+<script src="cordova.js"></script>
+<script src="js/achat.js"></script>
 <script src="js/pub.js"></script>
 
 <!-- Jeu -->


### PR DESCRIPTION
### Motivation
- Ensure Cordova APIs and the in-app purchase script are available before ad and game code runs by loading them earlier in the page.

### Description
- Inserted `<script src="cordova.js"></script>` and `<script src="js/achat.js"></script>` into `classic.html`, `infini.html`, and `concours.html` immediately before the `js/pub.js` include. 
- Preserved the existing script ordering otherwise so ad (`js/pub.js`) and game scripts (`js/game.js` / `js/concours.js`) still load after these new includes.

### Testing
- Verified the new script tags are present with `rg -n "cordova\.js|achat\.js|pub\.js|game\.js|concours\.js" classic.html infini.html concours.html` (succeeded). 
- Inspected the insertion lines with `nl -ba <file> | sed -n '<range>p'` to confirm correct placement (succeeded). 
- Reviewed the resulting diffs to confirm only the three HTML files were modified and no other changes were introduced (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e73aca18608321afd98f59e649d6a4)