### PR TITLE
Add global Firebase analytics module and event tracking hooks

### DIFF
--- a/boutique.html
+++ b/boutique.html
@@ -9,6 +9,7 @@
   <script src="js/vendor/supabase-2.42.5.min.js"></script>
 <script src="js/i18n.js"></script>
 <script src="js/userData.js"></script>
+<script src="js/analytics.js"></script>
 <script src="js/crossPromo.js"></script>
 
   <!-- Cordova (404 en web = normal) -->

--- a/classic.html
+++ b/classic.html
@@ -480,6 +480,7 @@
 <!-- App utils -->
 <script src="js/i18n.js"></script>
 <script src="js/userData.js"></script>
+<script src="js/analytics.js"></script>
 <script src="js/crossPromo.js"></script>
 <script src="js/referral.js"></script>
 

--- a/concours.html
+++ b/concours.html
@@ -462,6 +462,7 @@
   <!-- App utils -->
   <script src="js/i18n.js"></script>
   <script src="js/userData.js"></script>
+<script src="js/analytics.js"></script>
   <script src="js/crossPromo.js"></script>
   <script src="js/referral.js"></script>
   <!-- Ads -->

--- a/cross-promo.html
+++ b/cross-promo.html
@@ -378,6 +378,7 @@
   <script src="js/vendor/supabase-2.42.5.min.js"></script>
   <script src="js/i18n.js"></script>
   <script src="js/userData.js"></script>
+<script src="js/analytics.js"></script>
   <script src="js/crossPromo.js"></script>
   <script src="js/referral.js"></script>
 </head>

--- a/duel.html
+++ b/duel.html
@@ -393,6 +393,7 @@
   <script src="js/i18n.js"></script>
   <script src="js/pub.js"></script>
   <script src="js/userData.js"></script>
+<script src="js/analytics.js"></script>
   <script src="js/game_duel.js"></script>
 
   <script>

--- a/index.html
+++ b/index.html
@@ -229,6 +229,7 @@
   <script src="js/i18n.js"></script>
 
   <script src="js/userData.js"></script>
+<script src="js/analytics.js"></script>
   <script src="js/crossPromo.js"></script>
   <script src="js/referral.js"></script>
 

--- a/infini.html
+++ b/infini.html
@@ -402,6 +402,7 @@
 <!-- App utils -->
 <script src="js/i18n.js"></script>
 <script src="js/userData.js"></script>
+<script src="js/analytics.js"></script>
 <script src="js/crossPromo.js"></script>
 
 <!-- Ads -->

--- a/js/achat.js
+++ b/js/achat.js
@@ -325,6 +325,12 @@ if (S.when?.().approved) {
       markCredited(txId);
       removePending(txId);
 
+      try {
+        window.VRAnalytics?.logEvent?.('iap_success', {
+          product_id: String(productId)
+        });
+      } catch (_) {}
+
       try { await tx.finish(); } catch(_) {}
       FINISHED_TX.add(txId);
     } catch (e) {
@@ -429,10 +435,26 @@ document.addEventListener('resume', async () => {
 
       const offer = p?.getOffer && p.getOffer();
       let err = null;
+
+      try {
+        window.VRAnalytics?.logEvent?.('iap_attempt', {
+          product_id: String(productId)
+        });
+      } catch (_) {}
+
       if (offer?.order) err = await offer.order();
       else if (p?.order) err = await p.order();
 
-      if (err?.isError && DEBUG) warn('order err', err.code, err.message);
+      if (err?.isError) {
+        try {
+          window.VRAnalytics?.logEvent?.('iap_error', {
+            product_id: String(productId),
+            code: String(err.code || 'unknown')
+          });
+        } catch (_) {}
+
+        if (DEBUG) warn('order err', err.code, err.message);
+      }
     } catch(e) {
       warn('buy exception', e?.message||e);
     }

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,0 +1,277 @@
+// =============================
+// analytics.js — Firebase Analytics (no-import / global)
+// =============================
+(function () {
+  'use strict';
+
+  if (window.VRAnalytics) return;
+
+  var Cap = window.Capacitor || {};
+  var FirebaseAnalytics = null;
+
+  function getPlugin() {
+    if (FirebaseAnalytics) return FirebaseAnalytics;
+
+    try {
+      if (Cap.registerPlugin) {
+        FirebaseAnalytics = Cap.registerPlugin('FirebaseAnalytics');
+        return FirebaseAnalytics;
+      }
+    } catch (_) {}
+
+    try {
+      if (Cap.Plugins && Cap.Plugins.FirebaseAnalytics) {
+        FirebaseAnalytics = Cap.Plugins.FirebaseAnalytics;
+        return FirebaseAnalytics;
+      }
+    } catch (_) {}
+
+    return null;
+  }
+
+  function isNative() {
+    try {
+      if (Cap.getPlatform) return Cap.getPlatform() !== 'web';
+    } catch (_) {}
+
+    try {
+      if (Cap.isNativePlatform) return !!Cap.isNativePlatform();
+    } catch (_) {}
+
+    return !!window.cordova;
+  }
+
+  function getPlatformName() {
+    try {
+      if (Cap.getPlatform) return String(Cap.getPlatform() || 'web');
+    } catch (_) {}
+    return 'web';
+  }
+
+  function getPageName() {
+    try {
+      var file = (location.pathname || '').split('/').pop() || 'index.html';
+      file = file.toLowerCase();
+
+      if (file === '' || file === 'index.html') return 'index';
+
+      return file
+        .replace('.html', '')
+        .replace(/[^a-z0-9_-]/g, '_')
+        .replace(/-/g, '_');
+    } catch (_) {
+      return 'unknown';
+    }
+  }
+
+  function truncateString(value, maxLen) {
+    if (value === undefined || value === null) return undefined;
+    var s = String(value);
+    return s.length > maxLen ? s.slice(0, maxLen) : s;
+  }
+
+  function cleanParams(params) {
+    var out = {};
+    var src = params || {};
+
+    Object.keys(src).forEach(function (key) {
+      var value = src[key];
+
+      if (value === undefined || value === null || value === '') return;
+
+      if (typeof value === 'number') {
+        if (Number.isFinite(value)) out[key] = value;
+        return;
+      }
+
+      if (typeof value === 'boolean') {
+        out[key] = value ? 1 : 0;
+        return;
+      }
+
+      if (Array.isArray(value)) {
+        out[key] = truncateString(value.join(','), 100);
+        return;
+      }
+
+      out[key] = truncateString(value, 100);
+    });
+
+    return out;
+  }
+
+  async function logEvent(name, params) {
+    try {
+      if (!isNative()) return false;
+
+      var plugin = getPlugin();
+      if (!plugin || !plugin.logEvent) return false;
+
+      await plugin.logEvent({
+        name: String(name),
+        params: cleanParams(params)
+      });
+
+      return true;
+    } catch (e) {
+      console.warn('[analytics] logEvent failed:', name, e && e.message ? e.message : e);
+      return false;
+    }
+  }
+
+  async function setCurrentScreen(screenName) {
+    try {
+      if (!isNative()) return false;
+
+      var plugin = getPlugin();
+      if (!plugin || !plugin.setCurrentScreen) return false;
+
+      var screen = truncateString(screenName || getPageName(), 36) || 'unknown';
+
+      await plugin.setCurrentScreen({
+        screenName: screen,
+        screenClassOverride: screen
+      });
+
+      return true;
+    } catch (e) {
+      console.warn('[analytics] setCurrentScreen failed:', e && e.message ? e.message : e);
+      return false;
+    }
+  }
+
+  async function setUserIdFromApp() {
+    try {
+      if (!isNative()) return false;
+
+      var plugin = getPlugin();
+      if (!plugin || !plugin.setUserId) return false;
+
+      try {
+        if (window.userData && typeof window.userData.ensureAuth === 'function') {
+          await window.userData.ensureAuth();
+        }
+      } catch (_) {}
+
+      var uid = null;
+      try {
+        if (typeof window.getUserId === 'function') {
+          uid = await window.getUserId();
+        }
+      } catch (_) {}
+
+      await plugin.setUserId({
+        userId: uid || null
+      });
+
+      return true;
+    } catch (e) {
+      console.warn('[analytics] setUserId failed:', e && e.message ? e.message : e);
+      return false;
+    }
+  }
+
+  async function setUserProperty(key, value) {
+    try {
+      if (!isNative()) return false;
+
+      var plugin = getPlugin();
+      if (!plugin || !plugin.setUserProperty) return false;
+
+      await plugin.setUserProperty({
+        key: String(key),
+        value: value == null ? null : String(value)
+      });
+
+      return true;
+    } catch (e) {
+      console.warn('[analytics] setUserProperty failed:', key, e && e.message ? e.message : e);
+      return false;
+    }
+  }
+
+  async function refreshUserProperties() {
+    try {
+      await setUserProperty('language', (localStorage.getItem('langue') || 'EN').toUpperCase());
+      await setUserProperty('theme', localStorage.getItem('themeVBlocks') || 'cyber');
+      await setUserProperty('no_ads', localStorage.getItem('no_ads') === '1' ? '1' : '0');
+      await setUserProperty('platform', getPlatformName());
+    } catch (_) {}
+  }
+
+  var pageOpenSent = false;
+  var initRunning = false;
+
+  async function initPage() {
+    if (initRunning) return;
+    initRunning = true;
+
+    try {
+      await setUserIdFromApp();
+      await refreshUserProperties();
+
+      var page = getPageName();
+      var screenOk = await setCurrentScreen(page);
+
+      if (!pageOpenSent) {
+        var eventOk = await logEvent('page_open', { page: page });
+        if (screenOk || eventOk) pageOpenSent = true;
+      }
+    } finally {
+      initRunning = false;
+    }
+  }
+
+  function fireAndForget(promise) {
+    try {
+      if (promise && typeof promise.catch === 'function') {
+        promise.catch(function () {});
+      }
+    } catch (_) {}
+  }
+
+  window.VRAnalytics = {
+    getPlugin: getPlugin,
+    isNative: isNative,
+    getPageName: getPageName,
+    logEvent: logEvent,
+    setCurrentScreen: setCurrentScreen,
+    setUserIdFromApp: setUserIdFromApp,
+    setUserProperty: setUserProperty,
+    refreshUserProperties: refreshUserProperties,
+    initPage: initPage
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () {
+      fireAndForget(initPage());
+    }, { once: true });
+  } else {
+    fireAndForget(initPage());
+  }
+
+  document.addEventListener('deviceready', function () {
+    fireAndForget(initPage());
+  }, { once: true });
+
+  document.addEventListener('resume', function () {
+    fireAndForget(refreshUserProperties());
+    fireAndForget(setCurrentScreen(getPageName()));
+  });
+
+  window.addEventListener('storage', function (e) {
+    if (!e) return;
+    if (e.key === 'langue' || e.key === 'themeVBlocks' || e.key === 'no_ads') {
+      fireAndForget(refreshUserProperties());
+    }
+  });
+
+  window.addEventListener('vblocks-theme-changed', function (e) {
+    var theme = null;
+    try { theme = e && e.detail ? e.detail.theme : null; } catch (_) {}
+    fireAndForget(refreshUserProperties());
+    fireAndForget(logEvent('theme_change', {
+      theme: theme || (localStorage.getItem('themeVBlocks') || 'cyber')
+    }));
+  });
+})();

--- a/js/concours.js
+++ b/js/concours.js
@@ -737,7 +737,14 @@ function fillRectThemeSafe(c, px, py, size) {
     function showEndPopup(points) {
       if (endHandled) return;
       // ⚠️ on NE met PAS endHandled=true ici — on attend la confirmation fin
-      try { window.partieTerminee?.(); } catch(_){}
+      try {
+        window.partieTerminee?.({
+          mode: mode,
+          score: points,
+          linesCleared: linesCleared,
+          reviveUsed: reviveUsed
+        });
+      } catch(_){}
 
       paused = true;
       stopSoftDrop();

--- a/js/game.js
+++ b/js/game.js
@@ -908,7 +908,14 @@ overlay.querySelector('#resume-yes').onclick = () => {
     function showEndPopup(points) {
       if (endHandled) return;
       // ⚠️ on NE met PAS endHandled=true ici — on attend la confirmation fin
-      try { window.partieTerminee?.(); } catch(_){}
+      try {
+        window.partieTerminee?.({
+          mode: mode,
+          score: points,
+          linesCleared: linesCleared,
+          reviveUsed: reviveUsed
+        });
+      } catch(_){}
 
       paused = true;
       stopSoftDrop();

--- a/js/pub.js
+++ b/js/pub.js
@@ -720,6 +720,12 @@
         return;
       }
 
+      try {
+        window.VRAnalytics?.logEvent?.('rewarded_request', {
+          reward_type: String(type || 'unknown')
+        });
+      } catch (_) {}
+
       await ensureAuth();
       var adConsent = await ensureCanRequestAds();
 
@@ -756,23 +762,47 @@
           new Promise(function (res) { setTimeout(function(){ res('timeout'); }, 60000); })
         ]);
 
-        if (outcome === 'timeout') { onDone && onDone(false); return; }
+        if (outcome === 'timeout') {
+          try {
+            window.VRAnalytics?.logEvent?.('rewarded_result', {
+              reward_type: 'revive',
+              success: 0
+            });
+          } catch (_) {}
+          onDone && onDone(false);
+          return;
+        }
 
         if (outcome !== 'dismissed') {
           await Promise.race([ dismissedP.catch(function(){}), waitAppReturnOnce() ]);
         }
 
         try { await refreshBalanceUntil(3000, 800); } catch(_) {}
+        try {
+          window.VRAnalytics?.logEvent?.('rewarded_result', {
+            reward_type: 'revive',
+            success: 1
+          });
+        } catch (_) {}
         onDone && onDone(true);
         return;
       }
 
       var gotReward = await rewardedP;
       var credited  = await creditRewardClientSide(type, amount);
+      var rewardOk  = !!(gotReward || credited);
       await refreshBalanceUntil(5000, 800, type);
 
       showPromise.finally(function(){}).catch(function(){});
-      onDone && onDone(!!(gotReward || credited));
+      try {
+        window.VRAnalytics?.logEvent?.('rewarded_result', {
+          reward_type: String(type || 'unknown'),
+          success: rewardOk ? 1 : 0,
+          got_reward: gotReward ? 1 : 0,
+          credited: credited ? 1 : 0
+        });
+      } catch (_) {}
+      onDone && onDone(rewardOk);
       dismissedP.then(function(){}).catch(function(){});
 
     } catch (_e) {
@@ -990,6 +1020,11 @@
 
       if (res !== false) {
         markInterstitialShownNow();
+        try {
+          window.VRAnalytics?.logEvent?.('interstitial_show', {
+            page: window.VRAnalytics?.getPageName?.() || 'unknown'
+          });
+        } catch (_) {}
         setTimeout(function(){
           AdMob.prepareInterstitial({ adId: adId, requestOptions: buildAdMobRequestOptions(true) }).catch(function(){});
         }, 1200);
@@ -1047,6 +1082,13 @@
 
   async function partieCommencee(mode){
     mode = String(mode || 'classique').toLowerCase();
+
+    try {
+      window.VRAnalytics?.logEvent?.('game_start', {
+        mode: mode
+      });
+    } catch (_) {}
+
     if (window.__ads_waiting_choice) return;
     if (isModeInfini(mode) || isModeClassique(mode)) {
       await adsMarkGameLaunched(mode);
@@ -1055,6 +1097,13 @@
 
   async function partieReprisee(mode){
     mode = String(mode || 'classique').toLowerCase();
+
+    try {
+      window.VRAnalytics?.logEvent?.('game_resume', {
+        mode: mode
+      });
+    } catch (_) {}
+
     window.__ads_waiting_choice = false;
     if (isModeInfini(mode) || isModeClassique(mode)) {
       await adsMarkGameLaunched(mode);
@@ -1063,13 +1112,35 @@
 
   async function partieRecommencee(mode){
     mode = String(mode || 'classique').toLowerCase();
+
+    try {
+      window.VRAnalytics?.logEvent?.('game_restart', {
+        mode: mode
+      });
+    } catch (_) {}
+
     window.__ads_waiting_choice = false;
     if (isModeInfini(mode) || isModeClassique(mode)) {
       await adsMarkGameLaunched(mode);
     }
   }
 
-  function partieTerminee(){}
+  function partieTerminee(payload){
+    try {
+      var data = payload || {};
+      var mode = String(data.mode || 'classique').toLowerCase();
+      var score = Number(data.score || 0);
+      var lines = Number(data.linesCleared || 0);
+      var reviveUsed = !!data.reviveUsed;
+
+      window.VRAnalytics?.logEvent?.('game_end', {
+        mode: mode,
+        score: score,
+        lines_cleared: lines,
+        revive_used: reviveUsed ? 1 : 0
+      });
+    } catch (_) {}
+  }
 
   // =============================
   // Expose global

--- a/parametres.html
+++ b/parametres.html
@@ -377,6 +377,7 @@
   <script src="js/vendor/supabase-2.42.5.min.js"></script>
   <!-- Script qui utilise Supabase -->
   <script src="js/userData.js"></script>
+<script src="js/analytics.js"></script>
   <!-- Charger i18n AVANT le script inline pour pouvoir l'appeler -->
   <script src="js/i18n.js"></script>
   <script src="js/pub.js"></script>

--- a/profil.html
+++ b/profil.html
@@ -369,6 +369,7 @@
   <script src="js/vendor/supabase-2.42.5.min.js"></script>
 <script src="js/i18n.js"></script>
 <script src="js/userData.js"></script>
+<script src="js/analytics.js"></script>
 <script src="js/referral.js"></script>
 <script src="js/pub.js"></script>
   <script>


### PR DESCRIPTION
### Motivation
- Add a lightweight global analytics module to send Firebase Analytics events from native apps (Capacitor/Cordova) and centralize page/screen and user property handling.
- Instrument game lifecycle, ad flows and in-app purchases so important client-side events are reported for analytics and debugging.

### Description
- Add `js/analytics.js` which exposes `window.VRAnalytics` and implements `logEvent`, `setCurrentScreen`, `setUserIdFromApp`, `refreshUserProperties`, `initPage` and helpers for native plugin discovery and parameter cleaning.
- Include `js/analytics.js` right after `js/userData.js` in `index.html`, `classic.html`, `infini.html`, `duel.html`, `boutique.html`, `concours.html`, `cross-promo.html`, `parametres.html` and `profil.html`.
- Instrument `js/pub.js` to emit ad and game events: `rewarded_request`, `rewarded_result` (revive and standard variants), `interstitial_show`, and game lifecycle events `game_start`, `game_resume`, `game_restart`, `game_end` (with `mode`, `score`, `lines_cleared`, `revive_used`).
- Update `js/game.js` and `js/concours.js` to call `window.partieTerminee` with the real payload `{ mode, score, linesCleared, reviveUsed }` so `js/pub.js` can report `game_end` with accurate values.
- Add IAP tracking in `js/achat.js` emitting `iap_attempt`, `iap_error` (with `product_id` and `code`), and `iap_success`.

### Testing
- Ran `git status --short` to verify changes were staged and committed; command completed successfully.
- Verified the script inclusion with `rg -n "js/analytics.js"` across the modified HTML files; all insertions were found and succeeded.
- Verified instrumentation in `js/pub.js`, `js/game.js`, `js/concours.js`, and `js/achat.js` using `rg` searches for the new event names; matches found as expected.
- No unit/integration test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e743779d548321897758bc70525a22)