### PR TITLE
Update U piece shape in solo and duel modes

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -444,7 +444,7 @@ function fillRectThemeSafe(c, px, py, size) {
       [[0,1,1],[1,1,0]],             // S
       [[1,1,1],[0,1,0],[0,1,0]],     // T = vrai T en 5 cases
       [[1,1,0],[0,1,1]],             // Z
-      [[1,1,1],[1,0,1]]              // U = 5 cases
+      [[1,1,1],[1,0,1],[1,0,1]]      // U
     ];
     const LETTERS = ['I','J','L','O','S','T','Z','U'];
 

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -358,7 +358,7 @@ function fillRectThemeSafe(c, px, py, size) {
       [[0,1,1],[1,1,0]],             // S
       [[1,1,1],[0,1,0],[0,1,0]],     // T = vrai T en 5 cases
       [[1,1,0],[0,1,1]],             // Z
-      [[1,1,1],[1,0,1]]              // U = 5 cases
+      [[1,1,1],[1,0,1],[1,0,1]]      // U
     ];
     const LETTERS = ['I','J','L','O','S','T','Z','U'];
 


### PR DESCRIPTION
### Motivation
- Corriger la définition de la pièce `U` pour qu'elle occupe 3 lignes au lieu de 2 et uniformiser le comportement entre le mode solo et le mode duel.

### Description
- Remplacé l'entrée `U` dans la constante `PIECES` de `js/game.js` par `[[1,1,1],[1,0,1],[1,0,1]]`.
- Appliqué la même modification dans `js/game_duel.js` pour garder la cohérence entre les deux modes.
- Mis à jour les fichiers source et commité les changements.

### Testing
- Vérification de parsing JavaScript effectuée avec `node -e "const fs=require('fs'); new Function(fs.readFileSync('js/game.js','utf8')); new Function(fs.readFileSync('js/game_duel.js','utf8')); console.log('js parse ok')"` et réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a77dfdf4832188ba68b89e957fa0)