### PR TITLE
Fix preview scaling and piece ID bounds to include P/C

### DIFF
--- a/ads.html
+++ b/ads.html
@@ -367,7 +367,7 @@ function fillRectThemeSafe(c, px, py, size) {
     function generateSequenceClassic(bags = 200) {
       const res = [];
       for (let b = 0; b < bags; b++) {
-        const bag = [0,1,2,3,4,5,6,7,8,9]; // I,J,L,O,S,T,Z
+        const bag = [0,1,2,3,4,5,6,7,8,9]; // I,J,L,O,S,T,Z,U,P,C
         shuffle(bag);
         res.push(...bag);
       }
@@ -1406,7 +1406,7 @@ window.updateHighScoreDisplay = updateHighscoreDisplay;
       if (mode === 'duel') typeId = getDuelNextPieceId();
       else typeId = getNextPieceIdGeneric();
 
-      if (typeId < 0 || typeId > 7 || Number.isNaN(typeId)) {
+      if (typeId < 0 || typeId >= PIECES.length || Number.isNaN(typeId)) {
         typeId = Math.floor(Math.random() * PIECES.length);
       }
 
@@ -1779,9 +1779,15 @@ if (score > highscoreCloud) {
       const h = maxY - minY + 1;
 
       const PAD = 6;
+
+      // On garde une taille cohérente dans la preview.
+      // Sinon une pièce 1x1 comme Pixel devient énorme.
+      const previewCols = 5;
+      const previewRows = 3;
+
       const cellSize = Math.min(
-        (cssW - 2 * PAD) / w,
-        (cssH - 2 * PAD) / h
+        (cssW - 2 * PAD) / previewCols,
+        (cssH - 2 * PAD) / previewRows
       );
 
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;

--- a/js/concours.js
+++ b/js/concours.js
@@ -262,7 +262,7 @@ function fillRectThemeSafe(c, px, py, size) {
     function generateSequenceClassic(bags = 200) {
       const res = [];
       for (let b = 0; b < bags; b++) {
-        const bag = [0,1,2,3,4,5,6,7,8,9]; // I,J,L,O,S,T,Z
+        const bag = [0,1,2,3,4,5,6,7,8,9]; // I,J,L,O,S,T,Z,U,P,C
         shuffle(bag);
         res.push(...bag);
       }
@@ -1485,7 +1485,7 @@ function fillRectThemeSafe(c, px, py, size) {
       if (mode === 'duel') typeId = getDuelNextPieceId();
       else typeId = getNextPieceIdGeneric();
 
-      if (typeId < 0 || typeId > 7 || Number.isNaN(typeId)) {
+      if (typeId < 0 || typeId >= PIECES.length || Number.isNaN(typeId)) {
         typeId = Math.floor(Math.random() * PIECES.length);
       }
 
@@ -1832,9 +1832,15 @@ function fillRectThemeSafe(c, px, py, size) {
       const h = maxY - minY + 1;
 
       const PAD = 6;
+
+      // On garde une taille cohérente dans la preview.
+      // Sinon une pièce 1x1 comme Pixel devient énorme.
+      const previewCols = 5;
+      const previewRows = 3;
+
       const cellSize = Math.min(
-        (cssW - 2 * PAD) / w,
-        (cssH - 2 * PAD) / h
+        (cssW - 2 * PAD) / previewCols,
+        (cssH - 2 * PAD) / previewRows
       );
 
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;

--- a/js/game.js
+++ b/js/game.js
@@ -339,7 +339,7 @@ function fillRectThemeSafe(c, px, py, size) {
     function generateSequenceClassic(bags = 200) {
       const res = [];
       for (let b = 0; b < bags; b++) {
-        const bag = [0,1,2,3,4,5,6,7,8,9]; // I,J,L,O,S,T,Z
+        const bag = [0,1,2,3,4,5,6,7,8,9]; // I,J,L,O,S,T,Z,U,P,C
         shuffle(bag);
         res.push(...bag);
       }
@@ -1911,7 +1911,7 @@ window.updateHighScoreDisplay = updateHighscoreDisplay;
       if (mode === 'duel') typeId = getDuelNextPieceId();
       else typeId = getNextPieceIdGeneric();
 
-      if (typeId < 0 || typeId > 7 || Number.isNaN(typeId)) {
+      if (typeId < 0 || typeId >= PIECES.length || Number.isNaN(typeId)) {
         typeId = Math.floor(Math.random() * PIECES.length);
       }
 
@@ -2288,9 +2288,15 @@ if (score > highscoreCloud) {
       const h = maxY - minY + 1;
 
       const PAD = 6;
+
+      // On garde une taille cohérente dans la preview.
+      // Sinon une pièce 1x1 comme Pixel devient énorme.
+      const previewCols = 5;
+      const previewRows = 3;
+
       const cellSize = Math.min(
-        (cssW - 2 * PAD) / w,
-        (cssH - 2 * PAD) / h
+        (cssW - 2 * PAD) / previewCols,
+        (cssH - 2 * PAD) / previewRows
       );
 
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -807,7 +807,7 @@ function fillRectThemeSafe(c, px, py, size) {
 
     function newPiece() {
       let typeId = getDuelNextPieceId();
-      if (Number.isNaN(typeId) || typeId < 0 || typeId > 7) typeId = 3;
+      if (Number.isNaN(typeId) || typeId < 0 || typeId >= PIECES.length) typeId = 3;
       const letter = LETTERS[typeId];
       return createSafePiece(letter);
     }
@@ -1135,7 +1135,16 @@ function fillRectThemeSafe(c, px, py, size) {
       const h = maxY - minY + 1;
 
       const PAD = 6;
-      const cellSize = Math.min((cssW - 2 * PAD) / w, (cssH - 2 * PAD) / h);
+
+      // On garde une taille cohérente dans la preview.
+      // Sinon une pièce 1x1 comme Pixel devient énorme.
+      const previewCols = 5;
+      const previewRows = 3;
+
+      const cellSize = Math.min(
+        (cssW - 2 * PAD) / previewCols,
+        (cssH - 2 * PAD) / previewRows
+      );
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;
       const offsetY = (cssH - (h * cellSize)) / 2 - minY * cellSize;
 


### PR DESCRIPTION
### Motivation
- Prevent 1x1 pieces (Pixel) from rendering oversized in mini previews by using a consistent preview grid instead of per-piece dimensions.
- Allow the new `P` and `C` pieces to spawn by fixing overly strict `typeId` validation logic.
- Correct the classic-bag comment to reflect the actual 10-piece bag.

### Description
- Replace per-shape `cellSize` computation with a fixed preview grid (`previewCols = 5`, `previewRows = 3`) in `drawMiniPiece` across `js/game.js`, `js/game_duel.js`, `js/concours.js`, and `ads.html` so previews keep a consistent scale.
- Relax `newPiece()` bounds checks to use `typeId >= PIECES.length` (instead of `> 7`) in `js/game.js`, `js/concours.js`, `ads.html`, and `js/game_duel.js` so all piece IDs up to `PIECES.length - 1` (including `P` and `C`) are accepted.
- Update the `bag` comment in `js/game.js`, `js/concours.js`, and `ads.html` to `// I,J,L,O,S,T,Z,U,P,C` to match the actual 10-piece bag.

### Testing
- Ran `git diff --check` to verify no whitespace or diff errors, and it passed.
- Verified the updated occurrences with code search (`rg`) to confirm the new preview grid, bounds checks, and bag comment appear in the four target files; the search matched the intended replacements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec9d61b14c83218cf27136a02d8800)