### PR TITLE
Fix preview cell sizing for all pieces except Pixel

### DIFF
--- a/ads.html
+++ b/ads.html
@@ -1780,15 +1780,22 @@ if (score > highscoreCloud) {
 
       const PAD = 6;
 
-      // On garde une taille cohérente dans la preview.
-      // Sinon une pièce 1x1 comme Pixel devient énorme.
-      const previewCols = 5;
-      const previewRows = 3;
-
-      const cellSize = Math.min(
-        (cssW - 2 * PAD) / previewCols,
-        (cssH - 2 * PAD) / previewRows
+      // Taille normale : ancien comportement, donc toutes les pièces redeviennent comme avant.
+      const normalCellSize = Math.min(
+        (cssW - 2 * PAD) / w,
+        (cssH - 2 * PAD) / h
       );
+
+      // Exception uniquement pour Pixel : il doit rester un petit carré,
+      // pas remplir toute la preview.
+      const pixelCellSize = Math.min(
+        (cssW - 2 * PAD) / 5,
+        (cssH - 2 * PAD) / 3
+      );
+
+      const cellSize = (safePiece?.letter === 'P' || piece?.letter === 'P')
+        ? pixelCellSize
+        : normalCellSize;
 
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;
       const offsetY = (cssH - (h * cellSize)) / 2 - minY * cellSize;

--- a/js/concours.js
+++ b/js/concours.js
@@ -1833,15 +1833,22 @@ function fillRectThemeSafe(c, px, py, size) {
 
       const PAD = 6;
 
-      // On garde une taille cohérente dans la preview.
-      // Sinon une pièce 1x1 comme Pixel devient énorme.
-      const previewCols = 5;
-      const previewRows = 3;
-
-      const cellSize = Math.min(
-        (cssW - 2 * PAD) / previewCols,
-        (cssH - 2 * PAD) / previewRows
+      // Taille normale : ancien comportement, donc toutes les pièces redeviennent comme avant.
+      const normalCellSize = Math.min(
+        (cssW - 2 * PAD) / w,
+        (cssH - 2 * PAD) / h
       );
+
+      // Exception uniquement pour Pixel : il doit rester un petit carré,
+      // pas remplir toute la preview.
+      const pixelCellSize = Math.min(
+        (cssW - 2 * PAD) / 5,
+        (cssH - 2 * PAD) / 3
+      );
+
+      const cellSize = (safePiece?.letter === 'P' || piece?.letter === 'P')
+        ? pixelCellSize
+        : normalCellSize;
 
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;
       const offsetY = (cssH - (h * cellSize)) / 2 - minY * cellSize;

--- a/js/game.js
+++ b/js/game.js
@@ -2289,15 +2289,22 @@ if (score > highscoreCloud) {
 
       const PAD = 6;
 
-      // On garde une taille cohérente dans la preview.
-      // Sinon une pièce 1x1 comme Pixel devient énorme.
-      const previewCols = 5;
-      const previewRows = 3;
-
-      const cellSize = Math.min(
-        (cssW - 2 * PAD) / previewCols,
-        (cssH - 2 * PAD) / previewRows
+      // Taille normale : ancien comportement, donc toutes les pièces redeviennent comme avant.
+      const normalCellSize = Math.min(
+        (cssW - 2 * PAD) / w,
+        (cssH - 2 * PAD) / h
       );
+
+      // Exception uniquement pour Pixel : il doit rester un petit carré,
+      // pas remplir toute la preview.
+      const pixelCellSize = Math.min(
+        (cssW - 2 * PAD) / 5,
+        (cssH - 2 * PAD) / 3
+      );
+
+      const cellSize = (safePiece?.letter === 'P' || piece?.letter === 'P')
+        ? pixelCellSize
+        : normalCellSize;
 
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;
       const offsetY = (cssH - (h * cellSize)) / 2 - minY * cellSize;

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -1136,15 +1136,22 @@ function fillRectThemeSafe(c, px, py, size) {
 
       const PAD = 6;
 
-      // On garde une taille cohérente dans la preview.
-      // Sinon une pièce 1x1 comme Pixel devient énorme.
-      const previewCols = 5;
-      const previewRows = 3;
-
-      const cellSize = Math.min(
-        (cssW - 2 * PAD) / previewCols,
-        (cssH - 2 * PAD) / previewRows
+      // Taille normale : ancien comportement, donc toutes les pièces redeviennent comme avant.
+      const normalCellSize = Math.min(
+        (cssW - 2 * PAD) / w,
+        (cssH - 2 * PAD) / h
       );
+
+      // Exception uniquement pour Pixel : il doit rester un petit carré,
+      // pas remplir toute la preview.
+      const pixelCellSize = Math.min(
+        (cssW - 2 * PAD) / 5,
+        (cssH - 2 * PAD) / 3
+      );
+
+      const cellSize = (safePiece?.letter === 'P' || piece?.letter === 'P')
+        ? pixelCellSize
+        : normalCellSize;
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;
       const offsetY = (cssH - (h * cellSize)) / 2 - minY * cellSize;
 


### PR DESCRIPTION
### Motivation
- Restore legacy per-piece preview sizing so normal pieces retain their previous scale while Pixel remains a small square.
- A prior change used a fixed 5x3 preview grid which made 1x1 Pixel render oversized in previews.
- Apply a consistent fix across all preview draw routines referenced in the project.

### Description
- Replaced the fixed preview-grid calculation with `normalCellSize = Math.min((cssW - 2 * PAD) / w, (cssH - 2 * PAD) / h)` to recover historical sizing.
- Added `pixelCellSize = Math.min((cssW - 2 * PAD) / 5, (cssH - 2 * PAD) / 3)` and selected `cellSize` with the condition `safePiece?.letter === 'P' || piece?.letter === 'P'` so only `P` uses the small size.
- Kept `PAD` and centering (`offsetX` / `offsetY`) logic unchanged.
- Applied the same change in `js/game.js`, `js/game_duel.js`, `js/concours.js`, and `ads.html`.

### Testing
- Ran `rg -n "normalCellSize|pixelCellSize|safePiece\?\.letter === 'P'"` to confirm the replacement patterns exist in all modified files and it succeeded.
- Verified repository status with `git status --short` and committed the changes with `git commit` (commit message: "Fix preview cell sizing for all pieces except Pixel"), both succeeded.
- No automated visual/browser tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca0cee3208321b0c3a2ff1fab0978)