### PR TITLE
Fix preview redraw timing and Pixel mini-piece sizing

### DIFF
--- a/ads.html
+++ b/ads.html
@@ -1727,6 +1727,8 @@ if (score > highscoreCloud) {
       try {
         ensureRenderablePieces();
         drawBoard();
+        drawMiniPiece(nextCtx, nextPiece);
+        drawMiniPiece(holdCtx, heldPiece);
       } catch (e) {
         console.error('[VBlocks] drawBoard failed', e, {
           currentPiece,
@@ -1780,20 +1782,17 @@ if (score > highscoreCloud) {
 
       const PAD = 6;
 
-      // Taille normale : ancien comportement, donc toutes les pièces redeviennent comme avant.
       const normalCellSize = Math.min(
         (cssW - 2 * PAD) / w,
         (cssH - 2 * PAD) / h
       );
 
-      // Exception uniquement pour Pixel : il doit rester un petit carré,
-      // pas remplir toute la preview.
       const pixelCellSize = Math.min(
         (cssW - 2 * PAD) / 5,
         (cssH - 2 * PAD) / 3
       );
 
-      const cellSize = (safePiece?.letter === 'P' || piece?.letter === 'P')
+      const cellSize = safePiece.letter === 'P'
         ? pixelCellSize
         : normalCellSize;
 

--- a/js/concours.js
+++ b/js/concours.js
@@ -1805,7 +1805,11 @@ function fillRectThemeSafe(c, px, py, size) {
     }
 
     function safeRedraw() {
-      try { drawBoard(); } catch (_e) {}
+      try {
+        drawBoard();
+        drawMiniPiece(nextCtx, nextPiece);
+        drawMiniPiece(holdCtx, heldPiece);
+      } catch (_e) {}
     }
 
     function drawMiniPiece(c, piece) {
@@ -1833,20 +1837,17 @@ function fillRectThemeSafe(c, px, py, size) {
 
       const PAD = 6;
 
-      // Taille normale : ancien comportement, donc toutes les pièces redeviennent comme avant.
       const normalCellSize = Math.min(
         (cssW - 2 * PAD) / w,
         (cssH - 2 * PAD) / h
       );
 
-      // Exception uniquement pour Pixel : il doit rester un petit carré,
-      // pas remplir toute la preview.
       const pixelCellSize = Math.min(
         (cssW - 2 * PAD) / 5,
         (cssH - 2 * PAD) / 3
       );
 
-      const cellSize = (safePiece?.letter === 'P' || piece?.letter === 'P')
+      const cellSize = piece.letter === 'P'
         ? pixelCellSize
         : normalCellSize;
 

--- a/js/game.js
+++ b/js/game.js
@@ -2236,6 +2236,8 @@ if (score > highscoreCloud) {
       try {
         ensureRenderablePieces();
         drawBoard();
+        drawMiniPiece(nextCtx, nextPiece);
+        drawMiniPiece(holdCtx, heldPiece);
       } catch (e) {
         console.error('[VBlocks] drawBoard failed', e, {
           currentPiece,
@@ -2289,20 +2291,17 @@ if (score > highscoreCloud) {
 
       const PAD = 6;
 
-      // Taille normale : ancien comportement, donc toutes les pièces redeviennent comme avant.
       const normalCellSize = Math.min(
         (cssW - 2 * PAD) / w,
         (cssH - 2 * PAD) / h
       );
 
-      // Exception uniquement pour Pixel : il doit rester un petit carré,
-      // pas remplir toute la preview.
       const pixelCellSize = Math.min(
         (cssW - 2 * PAD) / 5,
         (cssH - 2 * PAD) / 3
       );
 
-      const cellSize = (safePiece?.letter === 'P' || piece?.letter === 'P')
+      const cellSize = safePiece.letter === 'P'
         ? pixelCellSize
         : normalCellSize;
 

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -1087,6 +1087,8 @@ function fillRectThemeSafe(c, px, py, size) {
       try {
         ensureRenderablePieces();
         drawBoard();
+        drawMiniPiece(nextCtx, nextPiece);
+        drawMiniPiece(holdCtx, heldPiece);
       } catch (e) {
         console.error('[VBlocks Duel] drawBoard failed', e, {
           currentPiece,
@@ -1136,20 +1138,17 @@ function fillRectThemeSafe(c, px, py, size) {
 
       const PAD = 6;
 
-      // Taille normale : ancien comportement, donc toutes les pièces redeviennent comme avant.
       const normalCellSize = Math.min(
         (cssW - 2 * PAD) / w,
         (cssH - 2 * PAD) / h
       );
 
-      // Exception uniquement pour Pixel : il doit rester un petit carré,
-      // pas remplir toute la preview.
       const pixelCellSize = Math.min(
         (cssW - 2 * PAD) / 5,
         (cssH - 2 * PAD) / 3
       );
 
-      const cellSize = (safePiece?.letter === 'P' || piece?.letter === 'P')
+      const cellSize = safePiece.letter === 'P'
         ? pixelCellSize
         : normalCellSize;
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;


### PR DESCRIPTION
### Motivation
- The preview mini-pieces were sometimes drawn before their images were ready, causing empty previews and inconsistent sizing for the Pixel piece.
- The Pixel piece must keep a small fixed preview size while all other pieces should retain the previous scaling behaviour.

### Description
- Updated `safeRedraw` to call `drawMiniPiece(nextCtx, nextPiece)` and `drawMiniPiece(holdCtx, heldPiece)` immediately after `drawBoard()` in `js/game.js`, `js/game_duel.js`, and `ads.html` to ensure previews are redrawn when the board is drawn.
- Changed `js/concours.js` `safeRedraw` to perform `drawBoard()` plus the two `drawMiniPiece` calls inside the `try` block so previews are attempted with normal redraw and still covered by the catch.
- Restored the original mini-piece sizing and added a Pixel-only exception by computing `normalCellSize` and `pixelCellSize`, then choosing `cellSize` based on the piece letter (`'P'`), and used `safePiece.letter` in game/duel/ads and `piece.letter` in `js/concours.js` as requested.
- Verified that `typeId` bounds checks already use `>= PIECES.length` in the targeted files, so no extra changes were needed there.

### Testing
- Ran syntax checks with `node --check js/game.js`, `node --check js/game_duel.js`, and `node --check js/concours.js`, and they all succeeded. 
- Confirmed files were updated and committed (`git status --short` then commit), and a PR record was created via the repository tooling. 
- Performed repository searches for the modified patterns (`rg`) to ensure replacements were applied; those searches returned the updated occurrences.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecbf24ea408321a5f0c7c7cbb3ab94)