### PR TITLE
Update rewind tutorial popup content and translations

### DIFF
--- a/data/AR.json
+++ b/data/AR.json
@@ -311,9 +311,10 @@
   "duel.rematch.sent": "تم إرسال طلب الإعادة",
   "duel.rematch.ask": "خصمك يطلب مباراة إعادة. هل تقبل؟",
   "duel.rematch.error": "تعذر بدء مباراة الإعادة الآن.",
-  "rewind.tip.title": "رجوع للخلف",
-  "rewind.tip.body": "عند الحاجة، يمكنك الضغط على هذا الزر للرجوع 5 قطع إلى الخلف.",
+  "rewind.tip.title": "هل تحتاج إلى مساعدة؟",
   "rewind.tip.cost": "التكلفة",
-  "rewind.tip.reward": "خذ، سنعطيك واحدًا لتجربته",
-  "rewind.tip.cta": "فهمت"
+  "rewind.tip.reward": "تفضل، سنمنحك واحدة لتجربتها",
+  "rewind.tip.cta": "فهمت",
+  "rewind.tip.line1": "يمكنك الضغط على هذا الزر للرجوع 5 قطع إلى الخلف.",
+  "rewind.tip.line2": "يمكنك الضغط على هذا الزر لإزالة آخر 5 أسطر."
 }

--- a/data/DE.json
+++ b/data/DE.json
@@ -311,9 +311,10 @@
   "duel.rematch.sent": "Revanche-Anfrage gesendet",
   "duel.rematch.ask": "Dein Gegner möchte eine Revanche. Annehmen?",
   "duel.rematch.error": "Eine Revanche kann im Moment nicht gestartet werden.",
-  "rewind.tip.title": "Zurück",
-  "rewind.tip.body": "Falls nötig, kannst du auf diese Taste tippen, um 5 Steine zurückzugehen.",
+  "rewind.tip.title": "Brauchst du Hilfe?",
   "rewind.tip.cost": "Kosten",
-  "rewind.tip.reward": "Hier, wir geben dir einen zum Ausprobieren",
-  "rewind.tip.cta": "Verstanden"
+  "rewind.tip.reward": "Hier, wir geben dir eins zum Ausprobieren",
+  "rewind.tip.cta": "Verstanden",
+  "rewind.tip.line1": "Du kannst auf diese Taste tippen, um 5 Teile zurückzugehen.",
+  "rewind.tip.line2": "Du kannst auf diese Taste tippen, um die unteren 5 Reihen zu entfernen."
 }

--- a/data/EN.json
+++ b/data/EN.json
@@ -311,9 +311,10 @@
   "duel.rematch.sent": "Rematch request sent",
   "duel.rematch.ask": "Your opponent is asking for a rematch. Accept?",
   "duel.rematch.error": "Unable to start a rematch right now.",
-  "rewind.tip.title": "Rewind",
-  "rewind.tip.body": "If needed, you can tap this button to go back 5 pieces.",
+  "rewind.tip.title": "Need help?",
   "rewind.tip.cost": "Cost",
-  "rewind.tip.reward": "Here, we’re giving you one to try it",
-  "rewind.tip.cta": "Got it"
+  "rewind.tip.reward": "Here, we’re giving you one to try it out",
+  "rewind.tip.cta": "Got it",
+  "rewind.tip.line1": "You can tap this button to go back 5 pieces.",
+  "rewind.tip.line2": "You can tap this button to remove the bottom 5 lines."
 }

--- a/data/ES-LATAM.json
+++ b/data/ES-LATAM.json
@@ -311,9 +311,10 @@
   "duel.rematch.sent": "Solicitud de revancha enviada",
   "duel.rematch.ask": "Tu rival propone una revancha. ¿La aceptas?",
   "duel.rematch.error": "No se puede iniciar la revancha por ahora.",
-  "rewind.tip.title": "Retroceder",
-  "rewind.tip.body": "Si lo necesitas, puedes tocar este botón para retroceder 5 piezas.",
+  "rewind.tip.title": "¿Necesitas ayuda?",
   "rewind.tip.cost": "Costo",
   "rewind.tip.reward": "Toma, te damos una para probarlo",
-  "rewind.tip.cta": "Entendido"
+  "rewind.tip.cta": "Entendido",
+  "rewind.tip.line1": "Puedes tocar este botón para retroceder 5 piezas.",
+  "rewind.tip.line2": "Puedes tocar este botón para eliminar las 5 líneas de abajo."
 }

--- a/data/ES.json
+++ b/data/ES.json
@@ -311,9 +311,10 @@
   "duel.rematch.sent": "Solicitud de revancha enviada",
   "duel.rematch.ask": "Tu rival propone una revancha. ¿Aceptar?",
   "duel.rematch.error": "No se puede iniciar la revancha por ahora.",
-  "rewind.tip.title": "Volver atrás",
-  "rewind.tip.body": "Si lo necesitas, puedes pulsar este botón para retroceder 5 piezas.",
+  "rewind.tip.title": "¿Necesitas ayuda?",
   "rewind.tip.cost": "Costo",
   "rewind.tip.reward": "Toma, te damos una para probarlo",
-  "rewind.tip.cta": "Entendido"
+  "rewind.tip.cta": "Entendido",
+  "rewind.tip.line1": "Puedes pulsar este botón para retroceder 5 piezas.",
+  "rewind.tip.line2": "Puedes pulsar este botón para eliminar las 5 líneas inferiores."
 }

--- a/data/FR.json
+++ b/data/FR.json
@@ -311,9 +311,10 @@
   "duel.rematch.sent": "Demande de revanche envoyée",
   "duel.rematch.ask": "Ton adversaire propose une revanche. Accepter ?",
   "duel.rematch.error": "Impossible de lancer la revanche pour le moment.",
-  "rewind.tip.title": "Retour en arrière",
-  "rewind.tip.body": "En cas de besoin, tu peux cliquer sur cette touche pour revenir 5 pièces en arrière.",
+  "rewind.tip.title": "Besoin d’aide ?",
   "rewind.tip.cost": "Coût",
   "rewind.tip.reward": "Tiens, on t’en donne un pour essayer",
-  "rewind.tip.cta": "Compris"
+  "rewind.tip.cta": "Compris",
+  "rewind.tip.line1": "Tu peux cliquer sur ce bouton pour revenir 5 pièces en arrière.",
+  "rewind.tip.line2": "Tu peux appuyer sur ce bouton pour supprimer les 5 lignes du bas."
 }

--- a/data/IDN.json
+++ b/data/IDN.json
@@ -311,9 +311,10 @@
   "duel.rematch.sent": "Permintaan tanding ulang dikirim",
   "duel.rematch.ask": "Lawanmu meminta tanding ulang. Terima?",
   "duel.rematch.error": "Tidak bisa memulai tanding ulang sekarang.",
-  "rewind.tip.title": "Mundur",
-  "rewind.tip.body": "Kalau perlu, kamu bisa menekan tombol ini untuk mundur 5 bidak.",
+  "rewind.tip.title": "Butuh bantuan?",
   "rewind.tip.cost": "Biaya",
-  "rewind.tip.reward": "Nih, kami kasih satu untuk mencobanya",
-  "rewind.tip.cta": "Mengerti"
+  "rewind.tip.reward": "Nih, kami kasih satu supaya kamu bisa mencobanya",
+  "rewind.tip.cta": "Mengerti",
+  "rewind.tip.line1": "Kamu bisa menekan tombol ini untuk mundur 5 keping.",
+  "rewind.tip.line2": "Kamu bisa menekan tombol ini untuk menghapus 5 baris terbawah."
 }

--- a/data/IT.json
+++ b/data/IT.json
@@ -311,9 +311,10 @@
   "duel.rematch.sent": "Richiesta di rivincita inviata",
   "duel.rematch.ask": "Il tuo avversario propone una rivincita. Accettare?",
   "duel.rematch.error": "Impossibile avviare una rivincita al momento.",
-  "rewind.tip.title": "Torna indietro",
-  "rewind.tip.body": "Se necessario, puoi toccare questo pulsante per tornare indietro di 5 pezzi.",
+  "rewind.tip.title": "Hai bisogno di aiuto?",
   "rewind.tip.cost": "Costo",
-  "rewind.tip.reward": "Tieni, te ne diamo uno per provarlo",
-  "rewind.tip.cta": "Capito"
+  "rewind.tip.reward": "Ecco, te ne diamo uno per provarlo",
+  "rewind.tip.cta": "Capito",
+  "rewind.tip.line1": "Puoi premere questo pulsante per tornare indietro di 5 pezzi.",
+  "rewind.tip.line2": "Puoi premere questo pulsante per eliminare le 5 righe inferiori."
 }

--- a/data/JP.json
+++ b/data/JP.json
@@ -311,9 +311,10 @@
   "duel.rematch.sent": "再戦リクエストを送信しました",
   "duel.rematch.ask": "相手が再戦を希望しています。受けますか？",
   "duel.rematch.error": "今は再戦を開始できません。",
-  "rewind.tip.title": "巻き戻し",
-  "rewind.tip.body": "必要なときは、このボタンを押すと5個前まで戻れます。",
-  "rewind.tip.cost": "必要数",
-  "rewind.tip.reward": "試せるように1つあげるね",
-  "rewind.tip.cta": "わかった"
+  "rewind.tip.title": "ヘルプが必要ですか？",
+  "rewind.tip.cost": "コスト",
+  "rewind.tip.reward": "お試し用に1つプレゼントします",
+  "rewind.tip.cta": "わかった",
+  "rewind.tip.line1": "このボタンを押すと5ピース戻れます。",
+  "rewind.tip.line2": "このボタンを押すと下の5ラインを消せます。"
 }

--- a/data/KO.json
+++ b/data/KO.json
@@ -311,9 +311,10 @@
   "duel.rematch.sent": "재대결 요청을 보냈습니다",
   "duel.rematch.ask": "상대가 재대결을 원합니다. 수락할까요?",
   "duel.rematch.error": "지금은 재대결을 시작할 수 없습니다.",
-  "rewind.tip.title": "되돌리기",
-  "rewind.tip.body": "필요할 때 이 버튼을 누르면 5개 전으로 돌아갈 수 있어요.",
+  "rewind.tip.title": "도움이 필요하신가요?",
   "rewind.tip.cost": "비용",
-  "rewind.tip.reward": "시험해 볼 수 있게 1개 줄게요",
-  "rewind.tip.cta": "알겠어요"
+  "rewind.tip.reward": "시험해 볼 수 있도록 하나 드릴게요",
+  "rewind.tip.cta": "알겠어요",
+  "rewind.tip.line1": "이 버튼을 누르면 5개 조각 전으로 돌아갈 수 있습니다.",
+  "rewind.tip.line2": "이 버튼을 누르면 아래 5줄을 제거할 수 있습니다."
 }

--- a/data/NL.json
+++ b/data/NL.json
@@ -311,9 +311,10 @@
   "duel.rematch.sent": "Rematch-verzoek verzonden",
   "duel.rematch.ask": "Je tegenstander wil een rematch. Accepteren?",
   "duel.rematch.error": "Kan nu geen rematch starten.",
-  "rewind.tip.title": "Terug",
-  "rewind.tip.body": "Als het nodig is, kun je op deze knop tikken om 5 stukken terug te gaan.",
+  "rewind.tip.title": "Hulp nodig?",
   "rewind.tip.cost": "Kosten",
-  "rewind.tip.reward": "Hier, we geven je er één om het te proberen",
-  "rewind.tip.cta": "Begrepen"
+  "rewind.tip.reward": "Hier, we geven je er één om het uit te proberen",
+  "rewind.tip.cta": "Begrepen",
+  "rewind.tip.line1": "Je kunt op deze knop drukken om 5 stukken terug te gaan.",
+  "rewind.tip.line2": "Je kunt op deze knop drukken om de onderste 5 lijnen te verwijderen."
 }

--- a/data/PT-BR.json
+++ b/data/PT-BR.json
@@ -311,9 +311,10 @@
   "duel.rematch.sent": "Pedido de revanche enviado",
   "duel.rematch.ask": "Seu adversário quer revanche. Aceitar?",
   "duel.rematch.error": "Não foi possível iniciar a revanche agora.",
-  "rewind.tip.title": "Voltar",
-  "rewind.tip.body": "Se precisar, você pode tocar neste botão para voltar 5 peças.",
+  "rewind.tip.title": "Precisa de ajuda?",
   "rewind.tip.cost": "Custo",
   "rewind.tip.reward": "Toma, a gente te dá uma para testar",
-  "rewind.tip.cta": "Entendi"
+  "rewind.tip.cta": "Entendi",
+  "rewind.tip.line1": "Você pode tocar neste botão para voltar 5 peças.",
+  "rewind.tip.line2": "Você pode tocar neste botão para remover as 5 linhas de baixo."
 }

--- a/data/PT.json
+++ b/data/PT.json
@@ -311,9 +311,10 @@
   "duel.rematch.sent": "Pedido de revanche enviado",
   "duel.rematch.ask": "O teu adversário quer revanche. Aceitas?",
   "duel.rematch.error": "Não foi possível iniciar a revanche agora.",
-  "rewind.tip.title": "Voltar atrás",
-  "rewind.tip.body": "Se precisares, podes tocar neste botão para recuar 5 peças.",
+  "rewind.tip.title": "Precisas de ajuda?",
   "rewind.tip.cost": "Custo",
   "rewind.tip.reward": "Toma, damos-te uma para experimentares",
-  "rewind.tip.cta": "Percebi"
+  "rewind.tip.cta": "Percebi",
+  "rewind.tip.line1": "Podes tocar neste botão para voltar 5 peças atrás.",
+  "rewind.tip.line2": "Podes tocar neste botão para remover as 5 linhas inferiores."
 }

--- a/js/game.js
+++ b/js/game.js
@@ -1798,13 +1798,22 @@ async function maybeShowRewindTutorialPopup() {
 
     popup.innerHTML = `
       <div style="width:min(92vw,360px);background:#23294a;border-radius:18px;padding:18px 16px;box-shadow:0 0 18px rgba(0,0,0,.35);text-align:center;">
-        <div style="display:flex;align-items:center;justify-content:center;gap:10px;margin-bottom:12px;">
-          <img src="assets/icons/rewind_5.svg" alt="" style="width:44px;height:44px;object-fit:contain;filter:drop-shadow(0 2px 8px rgba(0,0,0,.25));">
-          <div style="font-size:1.05em;font-weight:800;line-height:1.2;">${tt('rewind.tip.title', 'Retour en arrière')}</div>
+        <div style="font-size:1.12em;font-weight:800;line-height:1.2;margin-bottom:14px;">
+          ${tt('rewind.tip.title', 'Besoin d’aide ?')}
         </div>
 
-        <div style="opacity:.96;line-height:1.5;margin-bottom:10px;">
-          ${tt('rewind.tip.body', 'En cas de besoin, tu peux cliquer sur cette touche pour revenir 5 pièces en arrière.')}
+        <div style="display:flex;align-items:flex-start;justify-content:flex-start;gap:10px;margin-bottom:12px;text-align:left;">
+          <img src="assets/icons/rewind_5.svg" alt="" style="width:28px;height:28px;object-fit:contain;flex:0 0 28px;filter:drop-shadow(0 2px 8px rgba(0,0,0,.25));">
+          <div style="opacity:.96;line-height:1.45;">
+            ${tt('rewind.tip.line1', 'Tu peux cliquer sur ce bouton pour revenir 5 pièces en arrière.')}
+          </div>
+        </div>
+
+        <div style="display:flex;align-items:flex-start;justify-content:flex-start;gap:10px;margin-bottom:14px;text-align:left;">
+          <img src="assets/icons/clear_bottom_5.svg" alt="" style="width:28px;height:28px;object-fit:contain;flex:0 0 28px;filter:drop-shadow(0 2px 8px rgba(0,0,0,.25));">
+          <div style="opacity:.96;line-height:1.45;">
+            ${tt('rewind.tip.line2', 'Tu peux appuyer sur ce bouton pour supprimer les 5 lignes du bas.')}
+          </div>
         </div>
 
         <div style="display:flex;align-items:center;justify-content:center;gap:8px;margin-bottom:10px;font-weight:800;flex-wrap:nowrap;">
@@ -1816,7 +1825,7 @@ async function maybeShowRewindTutorialPopup() {
         </div>
 
         <div style="margin-bottom:14px;font-weight:800;text-align:center;">
-          ${tt('rewind.tip.reward', '')}
+          ${tt('rewind.tip.reward', 'Tiens, on t’en donne un pour essayer')}
         </div>
 
         <button id="rewind-tutorial-ok" style="padding:.78em 1.15em;border:none;border-radius:.85em;background:#39f;color:#fff;cursor:pointer;font-weight:800;">


### PR DESCRIPTION
### Motivation
- Improve the rewind tutorial popup to present two distinct actions (rewind and clear-bottom) with a clearer help layout and localized copy.
- Replace the single `rewind.tip.body` string with two separate lines for better translation and UI flexibility.

### Description
- Replaced the rewind tutorial HTML block in `js/game.js` with the new layout that uses `rewind.tip.title`, `rewind.tip.line1`, `rewind.tip.line2`, `rewind.tip.cost`, `rewind.tip.reward` and `rewind.tip.cta`.
- Migrated popup usage from `rewind.tip.body` to `rewind.tip.line1` and `rewind.tip.line2` and updated the default fallback strings in the template.
- Added/updated the six translation keys (`rewind.tip.title`, `rewind.tip.line1`, `rewind.tip.line2`, `rewind.tip.cost`, `rewind.tip.reward`, `rewind.tip.cta`) across all language files in `data/` (FR, EN, DE, ES, ES-LATAM, IT, NL, PT, PT-BR, IDN, JP, KO, AR) and removed the old `rewind.tip.body` entries.

### Testing
- Ran JSON syntax validation with `python -m json.tool data/FR.json` and `python -m json.tool data/EN.json`, both succeeded.
- Verified localization keys and replacements using ripgrep with `rg -n "rewind\.tip.(body|line1|line2|title|cost|reward|cta)" js/game.js data/*.json`, which showed the new keys are present.
- Confirmed there are no remaining references to `rewind.tip.body` using `rg -n "rewind\.tip\.body" data/*.json js/game.js`, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee36c768f0832184388659b2230256)