### PR TITLE
Fix popup close behavior for rewind and no-jeton dialogs

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1541,7 +1541,13 @@ function showRewindConfirmPopup() {
 
   document.body.appendChild(popup);
 
-  const closeOnly = () => popup.remove();
+  const closeOnly = () => {
+    if (popup.isConnected) popup.remove();
+    paused = false;
+    window.__ads_active = false;
+    window.__ads_freeze = false;
+    if (!gameOver) requestAnimationFrame(update);
+  };
 
   popup.querySelector('#rewind-cancel-btn')?.addEventListener('click', closeOnly);
   popup.addEventListener('click', (e) => {
@@ -1957,15 +1963,24 @@ function showNoJetonPopup(opts = {}) {
 
   document.body.appendChild(mini);
 
-  const closeMini = () => mini.remove();
+  const closeMini = (resumeGame = true) => {
+    if (mini.isConnected) mini.remove();
 
-  mini.querySelector('#no-jeton-close')?.addEventListener('click', closeMini);
+    if (resumeGame) {
+      paused = false;
+      window.__ads_active = false;
+      window.__ads_freeze = false;
+      if (!gameOver) requestAnimationFrame(update);
+    }
+  };
+
+  mini.querySelector('#no-jeton-close')?.addEventListener('click', () => closeMini(true));
   mini.addEventListener('click', (e) => {
-    if (e.target === mini) closeMini();
+    if (e.target === mini) closeMini(true);
   });
 
   mini.querySelector('#no-jeton-watch-ad')?.addEventListener('click', async () => {
-    closeMini();
+    closeMini(false);
     await onWatchAd();
   });
 


### PR DESCRIPTION
### Motivation
- Prevent the game from staying paused or in an inconsistent ad state after closing the rewind confirmation or the "no jeton" mini-popup.
- Avoid race conditions when the watch-ad flow is started so the game does not resume prematurely.

### Description
- Replace the simple `popup.remove()` in `showRewindConfirmPopup()` with a safe `closeOnly` that checks `popup.isConnected`, clears ad flags, unpauses the game and calls `requestAnimationFrame(update)` if appropriate.
- Replace the `closeMini` no-arg remover in `showNoJetonPopup()` with `closeMini(resumeGame = true)` that conditionally resumes the game and clears ad flags only when `resumeGame` is true.
- Update the `#no-jeton-close` and overlay click handlers to call `closeMini(true)` so the game resumes on cancel/overlay close, and call `closeMini(false)` before starting the ad flow so the game does not resume until after the ad completes.

### Testing
- Applied the patch to `js/game.js` successfully using the repository patch tool and verified the operation completed without errors.
- Located and inspected the modified regions with `nl -ba js/game.js | sed -n '1536,1565p;1958,1995p'` to confirm the new `closeOnly` and `closeMini` implementations.
- Searched for the original handlers with `rg` and validated that event listeners were updated to use `closeMini(true)` and `closeMini(false)` as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3499bfcf08321a474a3203f15764a)