### PR TITLE
Fix responsive top icons and cap preview piece scaling

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -148,19 +148,27 @@
       .main-title { font-size: .99em; }
       .btn-back { width: 32px; height: 32px; }
       .btn-back img, .btn-icon img { width: 20px; height: 20px; }
-      .wallet-block { gap: 8px; margin-bottom: 4px; }
-      .vcoin-icon, .jeton-icon { width: 16px; height: 16px; margin-right: 3px; }
-      .vcoins { font-size: .97em; }
-      .jetons { font-size: .88em; }
+      .wallet-block { gap: 14px; margin-bottom: 8px; }
+      .vcoin-icon, .jeton-icon { width: 18px; height: 18px; margin-right: 4px; }
+      .vcoins, .jetons { font-size: .97em; }
+      .top-canvas-row {
+        grid-template-columns: 72px minmax(116px, 1fr) 72px;
+        column-gap: 6px;
+        margin-top: 0;
+      }
+      .side-canvas-block label {
+        font-size: .9em;
+      }
     }
     .top-canvas-row {
       width: 100%;
       max-width: 410px;
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-end;
-      margin-bottom: 2px;
-      margin-top: -30px;
+      display: grid;
+      grid-template-columns: 82px minmax(118px, 1fr) 82px;
+      align-items: end;
+      column-gap: 8px;
+      margin-top: 0;
+      margin-bottom: 6px;
       flex-shrink: 0;
     }
 
@@ -168,27 +176,31 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 10px;
-      min-width: 96px;
-      padding-bottom: 6px;
+      gap: clamp(6px, 2vw, 10px);
+      min-width: 0;
+      padding-bottom: 8px;
     }
 
     .top-mini-action {
-      background: none;
+      width: clamp(42px, 12vw, 54px);
+      height: clamp(42px, 12vw, 54px);
+      background: rgba(255, 255, 255, 0.22);
       border: none;
       cursor: pointer;
-      padding: 2px;
-      border-radius: 99px;
+      padding: 0;
+      border-radius: 999px;
       display: flex;
       align-items: center;
       justify-content: center;
       touch-action: manipulation;
+      box-shadow: 0 4px 12px rgba(0,0,0,.08);
     }
 
     .top-mini-action img {
-      width: 36px;
-      height: 36px;
+      width: 62%;
+      height: 62%;
       display: block;
+      object-fit: contain;
     }
     .side-canvas-block {
       display: flex; flex-direction: column; align-items: center; gap: 2px;
@@ -281,7 +293,7 @@
       .top-canvas-row {
         width: min(100%, 700px) !important;
         max-width: 700px !important;
-        margin-top: -12px !important;
+        margin-top: 0 !important;
       }
 
       #gameCanvas {
@@ -318,7 +330,7 @@
       .top-canvas-row {
         width: min(100%, 560px) !important;
         max-width: 560px !important;
-        margin-top: -14px !important;
+        margin-top: 0 !important;
       }
 
       #gameCanvas {

--- a/concours.html
+++ b/concours.html
@@ -130,10 +130,17 @@
       .main-title { font-size: .99em; }
       .btn-back { width: 32px; height: 32px; }
       .btn-back img, .btn-icon img { width: 20px; height: 20px; }
-      .wallet-block { gap: 8px; margin-bottom: 4px; }
-      .vcoin-icon, .jeton-icon { width: 16px; height: 16px; margin-right: 3px; }
-      .vcoins { font-size: .97em; }
-      .jetons { font-size: .88em; }
+      .wallet-block { gap: 14px; margin-bottom: 8px; }
+      .vcoin-icon, .jeton-icon { width: 18px; height: 18px; margin-right: 4px; }
+      .vcoins, .jetons { font-size: .97em; }
+      .top-canvas-row {
+        grid-template-columns: 72px minmax(116px, 1fr) 72px;
+        column-gap: 6px;
+        margin-top: 0;
+      }
+      .side-canvas-block label {
+        font-size: .9em;
+      }
       .score-to-beat-row { margin: 2px 0 4px; }
     }
 
@@ -154,7 +161,7 @@
       .top-canvas-row {
         width: min(100%, 700px) !important;
         max-width: 700px !important;
-        margin-top: -12px !important;
+        margin-top: 0 !important;
       }
 
       #gameCanvas {
@@ -191,7 +198,7 @@
       .top-canvas-row {
         width: min(100%, 560px) !important;
         max-width: 560px !important;
-        margin-top: -14px !important;
+        margin-top: 0 !important;
       }
 
       #gameCanvas {
@@ -212,10 +219,14 @@
     }
 
     .top-canvas-row {
-      width: 100%; max-width: 410px;
-      display: flex; justify-content: space-between; align-items: flex-end;
-      margin-bottom: 2px;
-      margin-top: -30px;
+      width: 100%;
+      max-width: 410px;
+      display: grid;
+      grid-template-columns: 82px minmax(118px, 1fr) 82px;
+      align-items: end;
+      column-gap: 8px;
+      margin-top: 0;
+      margin-bottom: 6px;
       flex-shrink: 0;
     }
     .side-canvas-block {

--- a/duel.html
+++ b/duel.html
@@ -144,18 +144,29 @@
       .main-title { font-size: .99em; }
       .btn-back { width: 32px; height: 32px; }
       .btn-back img, .btn-icon img { width: 20px; height: 20px; }
-      .wallet-block { gap: 8px; margin-bottom: 4px; }
-      .vcoin-icon, .jeton-icon { width: 16px; height: 16px; margin-right: 3px; }
-      .vcoins { font-size: .97em; }
-      .jetons { font-size: .88em; }
+      .wallet-block { gap: 14px; margin-bottom: 8px; }
+      .vcoin-icon, .jeton-icon { width: 18px; height: 18px; margin-right: 4px; }
+      .vcoins, .jetons { font-size: .97em; }
+      .top-canvas-row {
+        grid-template-columns: 72px minmax(116px, 1fr) 72px;
+        column-gap: 6px;
+        margin-top: 0;
+      }
+      .side-canvas-block label {
+        font-size: .9em;
+      }
     }
 
     /* === Panneaux HOLD/NEXT + pause identiques === */
     .top-canvas-row {
-      width: 100%; max-width: 410px;
-      display: flex; justify-content: space-between; align-items: flex-end;
-      margin-bottom: 2px;
-      margin-top: -30px;
+      width: 100%;
+      max-width: 410px;
+      display: grid;
+      grid-template-columns: 82px minmax(118px, 1fr) 82px;
+      align-items: end;
+      column-gap: 8px;
+      margin-top: 0;
+      margin-bottom: 6px;
       flex-shrink: 0;
     }
     .side-canvas-block { display: flex; flex-direction: column; align-items: center; gap: 2px; }

--- a/infini.html
+++ b/infini.html
@@ -124,16 +124,27 @@
       .main-title { font-size: .99em; }
       .btn-back { width: 32px; height: 32px; }
       .btn-back img, .btn-icon img { width: 20px; height: 20px; }
-      .wallet-block { gap: 8px; margin-bottom: 4px; }
-      .vcoin-icon, .jeton-icon { width: 16px; height: 16px; margin-right: 3px; }
-      .vcoins { font-size: .97em; }
-      .jetons { font-size: .88em; }
+      .wallet-block { gap: 14px; margin-bottom: 8px; }
+      .vcoin-icon, .jeton-icon { width: 18px; height: 18px; margin-right: 4px; }
+      .vcoins, .jetons { font-size: .97em; }
+      .top-canvas-row {
+        grid-template-columns: 72px minmax(116px, 1fr) 72px;
+        column-gap: 6px;
+        margin-top: 0;
+      }
+      .side-canvas-block label {
+        font-size: .9em;
+      }
     }
 .top-canvas-row {
-  width: 100%; max-width: 410px;
-  display: flex; justify-content: space-between; align-items: flex-end;
-  margin-bottom: 2px;
-  margin-top: -30px;
+  width: 100%;
+  max-width: 410px;
+  display: grid;
+  grid-template-columns: 82px minmax(118px, 1fr) 82px;
+  align-items: end;
+  column-gap: 8px;
+  margin-top: 0;
+  margin-bottom: 6px;
   flex-shrink: 0;
     }
     .side-canvas-block {
@@ -211,7 +222,7 @@
       .top-canvas-row {
         width: min(100%, 700px) !important;
         max-width: 700px !important;
-        margin-top: -12px !important;
+        margin-top: 0 !important;
       }
 
       #gameCanvas {
@@ -248,7 +259,7 @@
       .top-canvas-row {
         width: min(100%, 560px) !important;
         max-width: 560px !important;
-        margin-top: -14px !important;
+        margin-top: 0 !important;
       }
 
       #gameCanvas {

--- a/js/concours.js
+++ b/js/concours.js
@@ -1847,9 +1847,19 @@ function fillRectThemeSafe(c, px, py, size) {
         (cssH - 2 * PAD) / 3
       );
 
+      /*
+        Correction preview :
+        les petites pièces 2x2 comme C ne doivent pas être zoomées
+        plus fort que les pièces normales 3x3.
+      */
+      const maxNormalPreviewCellSize = Math.min(
+        (cssW - 2 * PAD) / 3,
+        (cssH - 2 * PAD) / 3
+      );
+
       const cellSize = piece.letter === 'P'
         ? pixelCellSize
-        : normalCellSize;
+        : Math.min(normalCellSize, maxNormalPreviewCellSize);
 
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;
       const offsetY = (cssH - (h * cellSize)) / 2 - minY * cellSize;

--- a/js/game.js
+++ b/js/game.js
@@ -2528,9 +2528,19 @@ if (score > highscoreCloud) {
         (cssH - 2 * PAD) / 3
       );
 
+      /*
+        Correction preview :
+        les petites pièces 2x2 comme C ne doivent pas être zoomées
+        plus fort que les pièces normales 3x3.
+      */
+      const maxNormalPreviewCellSize = Math.min(
+        (cssW - 2 * PAD) / 3,
+        (cssH - 2 * PAD) / 3
+      );
+
       const cellSize = safePiece.letter === 'P'
         ? pixelCellSize
-        : normalCellSize;
+        : Math.min(normalCellSize, maxNormalPreviewCellSize);
 
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;
       const offsetY = (cssH - (h * cellSize)) / 2 - minY * cellSize;

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -1148,9 +1148,19 @@ function fillRectThemeSafe(c, px, py, size) {
         (cssH - 2 * PAD) / 3
       );
 
+      /*
+        Correction preview :
+        les petites pièces 2x2 comme C ne doivent pas être zoomées
+        plus fort que les pièces normales 3x3.
+      */
+      const maxNormalPreviewCellSize = Math.min(
+        (cssW - 2 * PAD) / 3,
+        (cssH - 2 * PAD) / 3
+      );
+
       const cellSize = safePiece.letter === 'P'
         ? pixelCellSize
-        : normalCellSize;
+        : Math.min(normalCellSize, maxNormalPreviewCellSize);
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;
       const offsetY = (cssH - (h * cellSize)) / 2 - minY * cellSize;
 


### PR DESCRIPTION
### Motivation
- Stabiliser l’affichage des icônes/contrôles en haut des pages et corriger l’espacement mobile du wallet pour éviter des chevauchements et targets tactiles trop petites.
- Éliminer les margin-top négatifs en mode tablette qui remontaient artificiellement les blocs après les corrections desktop/mobile.
- Empêcher la preview des petites pièces (ex. C 2x2) d’être agrandie plus que les pièces normales 3x3 dans les miniatures.

### Description
- Remplace `.top-canvas-row` de flex à une grille 3-colonnes dans `classic.html`, `infini.html`, `duel.html` et `concours.html` et ajuste les espacements (`margin-top:0`, `margin-bottom:6px`, `column-gap`).
- Met à jour uniquement dans `classic.html` les styles `.center-top-controls`, `.top-mini-action` et `.top-mini-action img` pour des dimensions et un rendu tactile responsives et une meilleure présentation d’icônes.
- Ajuste le bloc mobile `@media (max-width:480px)` dans les 4 fichiers HTML pour augmenter l’espace du wallet, agrandir les icônes `.vcoin-icon/.jeton-icon`, harmoniser les tailles `.vcoins/.jetons`, ajouter une grille mobile pour `.top-canvas-row` et réduire la taille des labels latéraux.
- Remplace les overrides tablettes `margin-top: -12px !important` et `margin-top: -14px !important` par `margin-top: 0 !important` dans `classic.html`, `infini.html` et `concours.html`.
- Dans `js/game.js`, `js/game_duel.js` et `js/concours.js`, ajoute `maxNormalPreviewCellSize` et plafonne la taille de cellule des pièces normales via `Math.min(normalCellSize, maxNormalPreviewCellSize)` tout en conservant le comportement spécial pour les pièces `P` (pixel pieces).

### Testing
- No automated tests were executed for these UI/CSS/JS visual adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60c901bd08321a9735d4ff97805c9)