### PR TITLE
Fix duel piece generation to include all 10 pieces

### DIFF
--- a/duel.html
+++ b/duel.html
@@ -592,7 +592,7 @@
       if (e2) { console.error(e2); alert('Lecture duel failed'); return; }
 
       if (data && !data.pieces_seq) {
-        const seq = Array.from({ length: 1000 }, () => Math.floor(Math.random() * 7)).join(',');
+        const seq = Array.from({ length: 1000 }, () => Math.floor(Math.random() * 10)).join(',');
         const { error: e3 } = await window.sb.from('duels')
           .update({ pieces_seq: seq, status: "started" })
           .eq('id', duelId);

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -509,7 +509,7 @@ function fillRectThemeSafe(c, px, py, size) {
     async function setupDuelSequence() {
       if (!duelId || !sb) {
         // fallback solo/random si pas d’ID (démo locale)
-        piecesSequence = Array.from({ length: 1000 }, () => Math.floor(Math.random() * 8));
+        piecesSequence = Array.from({ length: 1000 }, () => Math.floor(Math.random() * PIECES.length));
         piecesUsed = 0;
         return;
       }


### PR DESCRIPTION
### Motivation
- Duel piece selection used hardcoded random bounds which excluded the custom pieces `U`, `P`, and `C` from both the local fallback and the shared Supabase duel sequence.

### Description
- In `js/game_duel.js` replaced `Math.floor(Math.random() * 8)` with `Math.floor(Math.random() * PIECES.length)` for the local fallback sequence generation.
- In `duel.html` replaced `Math.floor(Math.random() * 7)` with `Math.floor(Math.random() * 10)` so the shared duel sequence covers indices `0..9`.
- This aligns the generation logic with the existing fallback in `getDuelNextPieceId()` which already uses `PIECES.length`.

### Testing
- Ran `rg -n "Math\.floor\(Math\.random\(\) \* (8|7)\)" js/game_duel.js duel.html` and confirmed the old patterns are no longer present.
- Inspected changes with `git diff -- js/game_duel.js duel.html` and viewed the modified lines with `nl -ba` to confirm the replacements were written to the files.
- There are no dedicated unit tests for sequence generation; the automated search and diff checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60dfaefc88321af70d01f9335c8bc)