### PR TITLE
Revert responsive/header and preview-size changes to original behavior

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -148,60 +148,48 @@
       .main-title { font-size: .99em; }
       .btn-back { width: 32px; height: 32px; }
       .btn-back img, .btn-icon img { width: 20px; height: 20px; }
-      .wallet-block { gap: 14px; margin-bottom: 8px; }
-      .vcoin-icon, .jeton-icon { width: 18px; height: 18px; margin-right: 4px; }
-      .vcoins, .jetons { font-size: .97em; }
-      .top-canvas-row {
-        grid-template-columns: 72px minmax(116px, 1fr) 72px;
-        column-gap: 6px;
-        margin-top: 0;
-      }
-      .side-canvas-block label {
-        font-size: .9em;
-      }
+      .wallet-block { gap: 8px; margin-bottom: 4px; }
+      .vcoin-icon, .jeton-icon { width: 16px; height: 16px; margin-right: 3px; }
+      .vcoins { font-size: .97em; }
+      .jetons { font-size: .88em; }
     }
     .top-canvas-row {
-      width: 100%;
-      max-width: 410px;
-      display: grid;
-      grid-template-columns: 82px minmax(118px, 1fr) 82px;
-      align-items: end;
-      column-gap: 8px;
-      margin-top: 0;
-      margin-bottom: 6px;
-      flex-shrink: 0;
-    }
+  width: 100%;
+  max-width: 410px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 2px;
+  margin-top: -30px;
+  flex-shrink: 0;
+}
 
     .center-top-controls {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: clamp(6px, 2vw, 10px);
-      min-width: 0;
-      padding-bottom: 8px;
-    }
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-width: 96px;
+  padding-bottom: 6px;
+}
 
     .top-mini-action {
-      width: clamp(42px, 12vw, 54px);
-      height: clamp(42px, 12vw, 54px);
-      background: rgba(255, 255, 255, 0.22);
-      border: none;
-      cursor: pointer;
-      padding: 0;
-      border-radius: 999px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      touch-action: manipulation;
-      box-shadow: 0 4px 12px rgba(0,0,0,.08);
-    }
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px;
+  border-radius: 99px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: manipulation;
+}
 
     .top-mini-action img {
-      width: 62%;
-      height: 62%;
-      display: block;
-      object-fit: contain;
-    }
+  width: 36px;
+  height: 36px;
+  display: block;
+}
     .side-canvas-block {
       display: flex; flex-direction: column; align-items: center; gap: 2px;
     }
@@ -293,7 +281,7 @@
       .top-canvas-row {
         width: min(100%, 700px) !important;
         max-width: 700px !important;
-        margin-top: 0 !important;
+        margin-top: -12px !important;
       }
 
       #gameCanvas {
@@ -330,7 +318,7 @@
       .top-canvas-row {
         width: min(100%, 560px) !important;
         max-width: 560px !important;
-        margin-top: 0 !important;
+        margin-top: -14px !important;
       }
 
       #gameCanvas {
@@ -349,6 +337,17 @@
         height: 60px !important;
       }
     }
+@media (max-width: 380px) {
+  .top-mini-action img {
+    width: 32px;
+    height: 32px;
+    object-fit: contain;
+  }
+
+  .center-top-controls {
+    gap: 6px;
+  }
+}
 </style>
 </head>
 <body>

--- a/concours.html
+++ b/concours.html
@@ -130,17 +130,10 @@
       .main-title { font-size: .99em; }
       .btn-back { width: 32px; height: 32px; }
       .btn-back img, .btn-icon img { width: 20px; height: 20px; }
-      .wallet-block { gap: 14px; margin-bottom: 8px; }
-      .vcoin-icon, .jeton-icon { width: 18px; height: 18px; margin-right: 4px; }
-      .vcoins, .jetons { font-size: .97em; }
-      .top-canvas-row {
-        grid-template-columns: 72px minmax(116px, 1fr) 72px;
-        column-gap: 6px;
-        margin-top: 0;
-      }
-      .side-canvas-block label {
-        font-size: .9em;
-      }
+      .wallet-block { gap: 8px; margin-bottom: 4px; }
+      .vcoin-icon, .jeton-icon { width: 16px; height: 16px; margin-right: 3px; }
+      .vcoins { font-size: .97em; }
+      .jetons { font-size: .88em; }
       .score-to-beat-row { margin: 2px 0 4px; }
     }
 
@@ -161,7 +154,7 @@
       .top-canvas-row {
         width: min(100%, 700px) !important;
         max-width: 700px !important;
-        margin-top: 0 !important;
+        margin-top: -12px !important;
       }
 
       #gameCanvas {
@@ -198,7 +191,7 @@
       .top-canvas-row {
         width: min(100%, 560px) !important;
         max-width: 560px !important;
-        margin-top: 0 !important;
+        margin-top: -14px !important;
       }
 
       #gameCanvas {
@@ -219,16 +212,15 @@
     }
 
     .top-canvas-row {
-      width: 100%;
-      max-width: 410px;
-      display: grid;
-      grid-template-columns: 82px minmax(118px, 1fr) 82px;
-      align-items: end;
-      column-gap: 8px;
-      margin-top: 0;
-      margin-bottom: 6px;
-      flex-shrink: 0;
-    }
+  width: 100%;
+  max-width: 410px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 2px;
+  margin-top: -30px;
+  flex-shrink: 0;
+}
     .side-canvas-block {
       display: flex; flex-direction: column; align-items: center; gap: 2px;
     }

--- a/duel.html
+++ b/duel.html
@@ -144,31 +144,23 @@
       .main-title { font-size: .99em; }
       .btn-back { width: 32px; height: 32px; }
       .btn-back img, .btn-icon img { width: 20px; height: 20px; }
-      .wallet-block { gap: 14px; margin-bottom: 8px; }
-      .vcoin-icon, .jeton-icon { width: 18px; height: 18px; margin-right: 4px; }
-      .vcoins, .jetons { font-size: .97em; }
-      .top-canvas-row {
-        grid-template-columns: 72px minmax(116px, 1fr) 72px;
-        column-gap: 6px;
-        margin-top: 0;
-      }
-      .side-canvas-block label {
-        font-size: .9em;
-      }
+      .wallet-block { gap: 8px; margin-bottom: 4px; }
+      .vcoin-icon, .jeton-icon { width: 16px; height: 16px; margin-right: 3px; }
+      .vcoins { font-size: .97em; }
+      .jetons { font-size: .88em; }
     }
 
     /* === Panneaux HOLD/NEXT + pause identiques === */
     .top-canvas-row {
-      width: 100%;
-      max-width: 410px;
-      display: grid;
-      grid-template-columns: 82px minmax(118px, 1fr) 82px;
-      align-items: end;
-      column-gap: 8px;
-      margin-top: 0;
-      margin-bottom: 6px;
-      flex-shrink: 0;
-    }
+  width: 100%;
+  max-width: 410px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 2px;
+  margin-top: -30px;
+  flex-shrink: 0;
+}
     .side-canvas-block { display: flex; flex-direction: column; align-items: center; gap: 2px; }
     .side-canvas-block label {
       font-size: 1em; font-weight: 700; margin-bottom: 2px; color: var(--panel-text, #39ff14);

--- a/infini.html
+++ b/infini.html
@@ -124,29 +124,21 @@
       .main-title { font-size: .99em; }
       .btn-back { width: 32px; height: 32px; }
       .btn-back img, .btn-icon img { width: 20px; height: 20px; }
-      .wallet-block { gap: 14px; margin-bottom: 8px; }
-      .vcoin-icon, .jeton-icon { width: 18px; height: 18px; margin-right: 4px; }
-      .vcoins, .jetons { font-size: .97em; }
-      .top-canvas-row {
-        grid-template-columns: 72px minmax(116px, 1fr) 72px;
-        column-gap: 6px;
-        margin-top: 0;
-      }
-      .side-canvas-block label {
-        font-size: .9em;
-      }
+      .wallet-block { gap: 8px; margin-bottom: 4px; }
+      .vcoin-icon, .jeton-icon { width: 16px; height: 16px; margin-right: 3px; }
+      .vcoins { font-size: .97em; }
+      .jetons { font-size: .88em; }
     }
 .top-canvas-row {
   width: 100%;
   max-width: 410px;
-  display: grid;
-  grid-template-columns: 82px minmax(118px, 1fr) 82px;
-  align-items: end;
-  column-gap: 8px;
-  margin-top: 0;
-  margin-bottom: 6px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 2px;
+  margin-top: -30px;
   flex-shrink: 0;
-    }
+}
     .side-canvas-block {
       display: flex; flex-direction: column; align-items: center; gap: 2px;
     }
@@ -222,7 +214,7 @@
       .top-canvas-row {
         width: min(100%, 700px) !important;
         max-width: 700px !important;
-        margin-top: 0 !important;
+        margin-top: -12px !important;
       }
 
       #gameCanvas {
@@ -259,7 +251,7 @@
       .top-canvas-row {
         width: min(100%, 560px) !important;
         max-width: 560px !important;
-        margin-top: 0 !important;
+        margin-top: -14px !important;
       }
 
       #gameCanvas {

--- a/js/concours.js
+++ b/js/concours.js
@@ -1852,14 +1852,9 @@ function fillRectThemeSafe(c, px, py, size) {
         les petites pièces 2x2 comme C ne doivent pas être zoomées
         plus fort que les pièces normales 3x3.
       */
-      const maxNormalPreviewCellSize = Math.min(
-        (cssW - 2 * PAD) / 3,
-        (cssH - 2 * PAD) / 3
-      );
-
       const cellSize = piece.letter === 'P'
         ? pixelCellSize
-        : Math.min(normalCellSize, maxNormalPreviewCellSize);
+        : normalCellSize;
 
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;
       const offsetY = (cssH - (h * cellSize)) / 2 - minY * cellSize;

--- a/js/game.js
+++ b/js/game.js
@@ -2533,14 +2533,9 @@ if (score > highscoreCloud) {
         les petites pièces 2x2 comme C ne doivent pas être zoomées
         plus fort que les pièces normales 3x3.
       */
-      const maxNormalPreviewCellSize = Math.min(
-        (cssW - 2 * PAD) / 3,
-        (cssH - 2 * PAD) / 3
-      );
-
       const cellSize = safePiece.letter === 'P'
         ? pixelCellSize
-        : Math.min(normalCellSize, maxNormalPreviewCellSize);
+        : normalCellSize;
 
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;
       const offsetY = (cssH - (h * cellSize)) / 2 - minY * cellSize;

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -1153,14 +1153,9 @@ function fillRectThemeSafe(c, px, py, size) {
         les petites pièces 2x2 comme C ne doivent pas être zoomées
         plus fort que les pièces normales 3x3.
       */
-      const maxNormalPreviewCellSize = Math.min(
-        (cssW - 2 * PAD) / 3,
-        (cssH - 2 * PAD) / 3
-      );
-
       const cellSize = safePiece.letter === 'P'
         ? pixelCellSize
-        : Math.min(normalCellSize, maxNormalPreviewCellSize);
+        : normalCellSize;
       const offsetX = (cssW - (w * cellSize)) / 2 - minX * cellSize;
       const offsetY = (cssH - (h * cellSize)) / 2 - minY * cellSize;
 


### PR DESCRIPTION
### Motivation
- Restore the original header/top-canvas responsive layout and spacing that was unintentionally changed.  
- Revert mobile wallet and header-button styling edits that altered icon sizes, gaps and backgrounds.  
- Undo the preview-size cap so small 2x2 pieces are rendered with the original sizing behavior while keeping a small requested responsive tweak for very small screens.

### Description
- Replaced the modified `.top-canvas-row` in `classic.html`, `infini.html`, `duel.html`, and `concours.html` with the original flex layout and original offsets (including `margin-top: -30px`).
- Reverted the mobile (`@media (max-width:480px)`) wallet and icon styles in all four HTML files and preserved `.score-to-beat-row` in `concours.html` where present. 
- Restored tablet portrait and landscape negative `margin-top` values in the tablet media blocks for the listed HTML files and restored the exact `top-canvas-row` widths in `concours.html`. 
- Reverted the preview cell-size cap logic in `js/game.js`, `js/game_duel.js`, and `js/concours.js` to use the original `normalCellSize`, and added only the requested `@media (max-width: 380px)` tweak in `classic.html` to reduce top-mini icons to 32px and tighten the gap.

### Testing
- Ran repository pattern searches and inspected the modified files to confirm the `.top-canvas-row`, wallet, and button style blocks were restored to the requested originals, and these checks passed.  
- Verified file diffs and file status to ensure only the intended HTML and JS files were changed, and the diffs matched the expected reversions.  
- Printed targeted file regions (line ranges) from the modified files to manually confirm the final CSS/JS blocks reflect the requested content, and those inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f61014053c832189a8ab73bd80b720)