### PR TITLE
Corrige overflow responsive (classic/duel) et réutilise le client Supabase global dans amis

### DIFF
--- a/amis.html
+++ b/amis.html
@@ -161,9 +161,10 @@
   </div>
   <script>
     // === SUPABASE CONFIG ===
-    const SUPABASE_URL = 'https://youhealyblgbwjhsskca.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlvdWhlYWx5YmxnYndqaHNza2NhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4NjAwMzcsImV4cCI6MjA2NDQzNjAzN30.2PUwMKq-xQOF3d2J_gg9EkZSBEbR-X5DachRUp6Auiw';
-    const sb = supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+    // Réutilise le client global (config active) si déjà initialisé, sinon fallback local.
+    const SUPABASE_URL = window.SUPABASE_URL || 'https://youhealyblgbwjhsskca.supabase.co';
+    const SUPABASE_ANON_KEY = window.SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlvdWhlYWx5YmxnYndqaHNza2NhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4NjAwMzcsImV4cCI6MjA2NDQzNjAzN30.2PUwMKq-xQOF3d2J_gg9EkZSBEbR-X5DachRUp6Auiw';
+    const sb = window.sb || supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
     let user = null;
     // Récupère l'utilisateur connecté (auth anonyme ou non)

--- a/classic.html
+++ b/classic.html
@@ -53,8 +53,8 @@
     .main-content {
       display: flex;
       flex-direction: column;
-      width: 430px;
-      max-width: none;
+      width: min(430px, 100vw);
+      max-width: 100vw;
       height: auto;
       min-height: 0;
       box-sizing: border-box;
@@ -143,8 +143,8 @@
     }
 
     @media (max-width:480px) {
-      .main-content { max-width: 100vw; }
-      .top-bar { padding: 4px 3px 0 3px; max-width: 99vw; }
+      .main-content { width: 100vw; max-width: 100vw; }
+      .top-bar { padding: 4px 3px 0 3px; max-width: 100vw; }
       .main-title { font-size: .99em; }
       .btn-back { width: 32px; height: 32px; }
       .btn-back img, .btn-icon img { width: 20px; height: 20px; }

--- a/duel.html
+++ b/duel.html
@@ -52,8 +52,8 @@
     .main-content {
       display: flex;
       flex-direction: column;
-      width: 430px;
-      max-width: none;
+      width: min(430px, 100vw);
+      max-width: 100vw;
       height: auto;
       min-height: 0;
       box-sizing: border-box;
@@ -139,8 +139,8 @@
     }
 
     @media (max-width:480px) {
-      .main-content { max-width: 100vw; }
-      .top-bar { padding: 4px 3px 0 3px; max-width: 99vw; }
+      .main-content { width: 100vw; max-width: 100vw; }
+      .top-bar { padding: 4px 3px 0 3px; max-width: 100vw; }
       .main-title { font-size: .99em; }
       .btn-back { width: 32px; height: 32px; }
       .btn-back img, .btn-icon img { width: 20px; height: 20px; }


### PR DESCRIPTION
### Motivation
- Éviter un débordement horizontal sur petits appareils en s'assurant que les conteneurs principaux ne dépassent pas la largeur de la fenêtre. 
- Ne plus forcer `amis.html` à utiliser une configuration Supabase codée en dur quand un client/config global est déjà initialisé.

### Description
- Remplace dans `classic.html` et `duel.html` `width: 430px; max-width: none;` par `width: min(430px, 100vw); max-width: 100vw;` pour limiter la largeur au viewport. 
- Aligne la media query mobile (`@media (max-width:480px)`) pour forcer `.main-content` à `width: 100vw; max-width: 100vw;` et met `top-bar` à `max-width: 100vw` au lieu de `99vw`. 
- Modifie `amis.html` pour réutiliser le client/config Supabase global si présent via `window.SUPABASE_URL`, `window.SUPABASE_ANON_KEY` et `window.sb`, avec un fallback local à `supabase.createClient(...)`.

### Testing
- Exécuté la recherche avec `rg -n "width:\s*430px|max-width:\s*none|@media \(max-width:480px\)|SUPABASE_URL|youhealyblgbwjhsskca" classic.html duel.html amis.html` et confirmé que les règles ciblées ont été remplacées et que `amis.html` contient désormais la logique de fallback global. 
- Inspecté les fichiers modifiés avec `nl -ba classic.html duel.html amis.html` pour vérifier la présence de `width: min(430px, 100vw)` et de `const sb = window.sb || supabase.createClient(...)`, ce qui a confirmé les remplacements.
- Généré la PR via l’outil de publication automatisée et vérifié le diff des fichiers modifiés, toutes les vérifications automatisées ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65e64580c83219001d33338d6ff6e)