### PR TITLE
Responsive top control icons and restore 3-icon layout in Infini

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -168,27 +168,30 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-  min-width: 96px;
+  gap: clamp(4px, 2.4vw, 10px);
+  min-width: 0;
   padding-bottom: 6px;
+  flex-shrink: 1;
 }
 
     .top-mini-action {
   background: none;
   border: none;
   cursor: pointer;
-  padding: 2px;
+  padding: clamp(1px, 0.6vw, 2px);
   border-radius: 99px;
   display: flex;
   align-items: center;
   justify-content: center;
   touch-action: manipulation;
+  flex: 0 1 auto;
 }
 
     .top-mini-action img {
-  width: 36px;
-  height: 36px;
+  width: clamp(30px, 10vw, 36px);
+  height: clamp(30px, 10vw, 36px);
   display: block;
+  object-fit: contain;
 }
     .side-canvas-block {
       display: flex; flex-direction: column; align-items: center; gap: 2px;

--- a/concours.html
+++ b/concours.html
@@ -284,7 +284,28 @@
       border-radius: 1.1em;
       background: rgba(255,255,255,.06);
     }
-  </style>
+  
+
+.top-mini-action {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: clamp(1px, 0.6vw, 2px);
+  border-radius: 99px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: manipulation;
+  flex: 0 1 auto;
+}
+
+.top-mini-action img {
+  width: clamp(30px, 10vw, 36px);
+  height: clamp(30px, 10vw, 36px);
+  display: block;
+  object-fit: contain;
+}
+</style>
 </head>
 <body>
   <canvas id="starfield" style="position:fixed; top:0; left:0; width:100vw; height:100vh; z-index:-1; display:none;"></canvas>
@@ -337,8 +358,8 @@
           <span class="score-to-beat-label" data-i18n="game.score_to_beat">Score à battre</span>&nbsp;:
           <span id="score-to-beat-value-legacy">--</span>
         </div>
-        <button id="pause-btn"  style="background:none;border:none;cursor:pointer;padding:2px;border-radius:99px;" >
-          <img src="assets/icons/pause.svg" alt="Pause" style="width:36px;height:36px;display:block;">
+        <button id="pause-btn" class="top-mini-action">
+          <img src="assets/icons/pause.svg" alt="Pause">
         </button>
       </div>
       <div class="side-canvas-block">

--- a/duel.html
+++ b/duel.html
@@ -309,6 +309,36 @@
         height: 60px !important;
       }
     }
+
+
+.center-top-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  padding-bottom: 6px;
+  flex-shrink: 1;
+}
+
+.top-mini-action {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: clamp(1px, 0.6vw, 2px);
+  border-radius: 99px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: manipulation;
+  flex: 0 1 auto;
+}
+
+.top-mini-action img {
+  width: clamp(30px, 10vw, 36px);
+  height: clamp(30px, 10vw, 36px);
+  display: block;
+  object-fit: contain;
+}
 </style>
 </head>
 <body>
@@ -353,9 +383,9 @@
         <label data-i18n="game.hold">Réserve</label>
         <canvas id="holdCanvas" width="48" height="48"></canvas>
       </div>
-      <div style="display:flex; flex-direction:column; align-items:center; justify-content:center; min-width:54px;">
-        <button id="pause-btn" style="background:none;border:none;cursor:pointer;padding:2px;border-radius:99px;">
-          <img src="assets/icons/pause.svg" alt="Pause" style="width:36px;height:36px;display:block;">
+      <div class="center-top-controls">
+        <button id="pause-btn" class="top-mini-action">
+          <img src="assets/icons/pause.svg" alt="Pause">
         </button>
       </div>
       <div class="side-canvas-block">

--- a/infini.html
+++ b/infini.html
@@ -270,6 +270,37 @@
         height: 60px !important;
       }
     }
+
+
+.center-top-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(4px, 2.4vw, 10px);
+  min-width: 0;
+  padding-bottom: 6px;
+  flex-shrink: 1;
+}
+
+.top-mini-action {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: clamp(1px, 0.6vw, 2px);
+  border-radius: 99px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: manipulation;
+  flex: 0 1 auto;
+}
+
+.top-mini-action img {
+  width: clamp(30px, 10vw, 36px);
+  height: clamp(30px, 10vw, 36px);
+  display: block;
+  object-fit: contain;
+}
 </style>
 </head>
 <body>
@@ -308,13 +339,17 @@
         <label>Réserve</label>
         <canvas id="holdCanvas" width="48" height="48"></canvas>
       </div>
-      <div style="display:flex; flex-direction:row; align-items:center; justify-content:center; gap:8px; min-width:92px;">
-        <button id="clear-bottom-btn" title="Valider les 5 lignes du bas" style="background:none;border:none;cursor:pointer;padding:2px;border-radius:99px;">
-          <img src="assets/icons/clear_bottom_5.svg" alt="Valider les 5 lignes du bas" style="width:36px;height:36px;display:block;">
+      <div class="center-top-controls">
+        <button id="clear-bottom-btn" class="top-mini-action" title="Valider les 5 lignes du bas">
+          <img src="assets/icons/clear_bottom_5.svg" alt="Valider les 5 lignes du bas">
         </button>
 
-        <button id="pause-btn" title="Pause" style="background:none;border:none;cursor:pointer;padding:2px;border-radius:99px;">
-          <img src="assets/icons/pause.svg" alt="Pause" style="width:36px;height:36px;display:block;">
+        <button id="pause-btn" class="top-mini-action" title="Pause">
+          <img src="assets/icons/pause.svg" alt="Pause">
+        </button>
+
+        <button id="rewind-btn" class="top-mini-action" title="Retour arrière">
+          <img src="assets/icons/rewind_5.svg" alt="Retour arrière">
         </button>
       </div>
       <div class="side-canvas-block">


### PR DESCRIPTION
### Motivation
- Rendre les contrôles top plus réactifs sur petits écrans en évitant que les icônes deviennent trop petites. 
- Remettre l’ensemble des 3 icônes (`clear-bottom`, `pause`, `rewind`) dans le mode `infini` pour retrouver la parité visuelle avec `classic`.
- Uniformiser le markup CSS des boutons top across les pages pour faciliter la maintenance.

### Description
- Modifié le CSS de `classic.html` pour remplacer les règles statiques par des règles responsives utilisant `clamp(...)`, `flex-shrink` et `object-fit` pour `.center-top-controls`, `.top-mini-action` et `.top-mini-action img`.
- Remplacé le bloc inline de boutons dans `infini.html` par le markup à base de classes (`center-top-controls` + `top-mini-action`) et restauré les 3 boutons `clear-bottom-btn`, `pause-btn` et `rewind-btn`, puis ajouté le bloc CSS correspondant avant `</style>`.
- Remplacé le conteneur inline du bouton pause dans `duel.html` par la structure `center-top-controls` + `top-mini-action` sans ajouter les boutons `clear_bottom_5.svg` ni `rewind_5.svg`.
- Remplacé uniquement le bouton pause dans `concours.html` pour utiliser la classe `top-mini-action` et ajouté le CSS de `.top-mini-action`/`img` avant `</style>`.

### Testing
- Local search to locate and verify targets was run with `rg -n "center-top-controls|top-mini-action|clear-bottom-btn|pause-btn|rewind-btn"` and returned the expected matches.
- Automated replacement script (Python) was executed to apply the changes and reported `done`, indicating successful modifications.
- Diffs and repository checks were inspected with `git diff -- classic.html infini.html duel.html concours.html` and `git status --short` / `git rev-parse --short HEAD`, confirming the changes are present in the working tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f664f0f1ac83219c1226a085103c78)