### PR TITLE
Harmonize responsive viewport layout across game modes

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -22,7 +22,8 @@
       --safe-bottom: env(safe-area-inset-bottom, 0px);
     }
 
-    html, body {
+    html,
+    body {
       margin: 0;
       padding: 0;
       width: 100%;
@@ -36,9 +37,9 @@
     }
 
     body {
+      width: 100%;
       min-height: 100dvh;
       height: 100dvh;
-      width: 100%;
     }
 
     .game-viewport {
@@ -51,13 +52,13 @@
     }
 
     .main-content {
-      display: flex;
-      flex-direction: column;
       width: min(430px, 100vw);
       max-width: 100vw;
       height: auto;
       min-height: 0;
       box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
       align-items: center;
       justify-content: flex-start;
       margin: 0 auto;
@@ -65,6 +66,7 @@
       transform-origin: top center;
       will-change: transform;
     }
+
     .top-bar {
       width: 100%;
       max-width: 430px;
@@ -76,158 +78,221 @@
       position: relative;
       z-index: 10;
       background: transparent;
+      flex: 0 0 auto;
     }
+
     .top-bar-row {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      justify-content: space-between;
       width: 100%;
+      min-width: 0;
+      display: grid;
+      grid-template-columns: 42px minmax(0, 1fr) 76px;
+      align-items: center;
       gap: 8px;
     }
+
     .btn-back {
-      background: none;
+      width: 42px;
+      height: 42px;
+      padding: 4px;
       border: none;
-      display: flex; align-items: center; justify-content: center;
-      border-radius: 50%; padding: 4px;
+      border-radius: 50%;
+      background: none;
       cursor: pointer;
-      width: 42px; height: 42px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       transition: background 0.15s;
     }
-    .btn-back img { width: 28px; height: 28px; filter: drop-shadow(0 1px 2px #0005);}
+
+    .btn-back img {
+      width: 28px;
+      height: 28px;
+      filter: drop-shadow(0 1px 2px #0005);
+    }
+
     .main-title {
-      flex: 1;
-      font-size: 1.25em; font-weight: 900;
+      min-width: 0;
+      font-size: 1.25em;
+      font-weight: 900;
       color: var(--title-color, #39ff14);
-      letter-spacing: 2px; line-height: 1.1;
+      letter-spacing: 2px;
+      line-height: 1.1;
       text-align: center;
-      white-space: pre-line;
+      white-space: normal;
       word-break: break-word;
       user-select: none;
     }
+
     .profile-row {
+      width: 76px;
+      min-width: 0;
       display: flex;
       flex-direction: row;
+      justify-content: flex-end;
       gap: 8px;
     }
-    .btn-icon img { width: 27px; height: 27px; }
+
+    .btn-icon img {
+      width: 27px;
+      height: 27px;
+    }
 
     .wallet-block {
       width: 100%;
+      min-height: 38px;
+      margin: 0 0 7px 0;
       display: flex;
       flex-direction: row;
       align-items: center;
       justify-content: center;
       gap: 18px;
-      margin: 0 0 7px 0;
-      min-height: 38px;
     }
-    .vcoins, .jetons {
+
+    .vcoins,
+    .jetons {
       display: flex;
       align-items: center;
-      font-weight: 700;
       justify-content: center;
+      font-weight: 700;
     }
+
     .vcoins {
       font-size: 1.19em;
       color: #ffd800;
     }
+
     .jetons {
       font-size: 1.07em;
       color: #ffd800;
     }
-    .vcoin-icon, .jeton-icon {
-      width: 27px; height: 27px;
+
+    .vcoin-icon,
+    .jeton-icon {
+      width: 27px;
+      height: 27px;
       vertical-align: middle;
       margin-right: 6px;
     }
 
-    @media (max-width:480px) {
-      .main-content { width: 100vw; max-width: 100vw; }
-      .top-bar { padding: 4px 3px 0 3px; max-width: 100vw; }
-      .main-title { font-size: .99em; }
-      .btn-back { width: 32px; height: 32px; }
-      .btn-back img, .btn-icon img { width: 20px; height: 20px; }
-      .wallet-block { gap: 8px; margin-bottom: 4px; }
-      .vcoin-icon, .jeton-icon { width: 16px; height: 16px; margin-right: 3px; }
-      .vcoins { font-size: .97em; }
-      .jetons { font-size: .88em; }
-    }
     .top-canvas-row {
-  width: 100%;
-  max-width: 410px;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-bottom: 2px;
-  margin-top: -30px;
-  flex-shrink: 0;
-}
+      width: min(410px, 100%);
+      max-width: 410px;
+      box-sizing: border-box;
+      display: grid;
+      grid-template-columns: minmax(62px, 78px) minmax(96px, 126px) minmax(62px, 78px);
+      align-items: end;
+      justify-content: center;
+      column-gap: clamp(5px, 2vw, 10px);
+      margin: -30px auto 2px auto;
+      padding: 0 6px;
+      flex: 0 0 auto;
+    }
+
+    .side-canvas-block {
+      width: 100%;
+      min-width: 0;
+      max-width: 78px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 2px;
+    }
+
+    .side-canvas-block label {
+      width: 100%;
+      max-width: 78px;
+      margin-bottom: 2px;
+      font-size: clamp(0.76rem, 3.4vw, 1rem);
+      font-weight: 700;
+      line-height: 1.05;
+      color: var(--panel-text, #39ff14);
+      text-align: center;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    #holdCanvas,
+    #nextCanvas {
+      width: clamp(54px, 18vw, 76px);
+      height: clamp(54px, 18vw, 76px);
+      max-width: 76px;
+      max-height: 76px;
+      background: var(--canvas-panel-bg, #161649);
+      border: 2px dashed var(--canvas-panel-border, #00fff7);
+      border-radius: 0.4em;
+      box-shadow: 0 2px 7px #39ff1411;
+      display: block;
+      margin: 0 auto;
+      box-sizing: border-box;
+    }
+
+    #holdCanvas {
+      cursor: pointer;
+      touch-action: manipulation;
+    }
 
     .center-top-controls {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: clamp(4px, 2.4vw, 10px);
-  min-width: 0;
-  padding-bottom: 6px;
-  flex-shrink: 1;
-}
+      width: 100%;
+      min-width: 0;
+      max-width: 126px;
+      box-sizing: border-box;
+      padding-bottom: 5px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: clamp(2px, 1.35vw, 6px);
+      overflow: hidden;
+    }
 
     .top-mini-action {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: clamp(1px, 0.6vw, 2px);
-  border-radius: 99px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  touch-action: manipulation;
-  flex: 0 1 auto;
-}
-
-    .top-mini-action img {
-  width: clamp(30px, 10vw, 36px);
-  height: clamp(30px, 10vw, 36px);
-  display: block;
-  object-fit: contain;
-}
-    .side-canvas-block {
-      display: flex; flex-direction: column; align-items: center; gap: 2px;
+      width: clamp(28px, 8.2vw, 36px);
+      height: clamp(28px, 8.2vw, 36px);
+      min-width: 0;
+      min-height: 0;
+      max-width: 36px;
+      max-height: 36px;
+      padding: 0;
+      margin: 0;
+      border: none;
+      border-radius: 999px;
+      background: transparent;
+      cursor: pointer;
+      touch-action: manipulation;
+      flex: 0 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
     }
-    .side-canvas-block label {
-      font-size: 1em; font-weight: 700; margin-bottom: 2px; color: var(--panel-text, #39ff14);
-      text-align: center;
-    }
-#holdCanvas, #nextCanvas {
-  background: var(--canvas-panel-bg, #161649);
-  border: 2px dashed var(--canvas-panel-border, #00fff7);
-  border-radius: 0.4em;
-  box-shadow: 0 2px 7px #39ff1411;
-  display: block;
-  margin: 0 auto;
-}
 
-#holdCanvas {
-  cursor: pointer;
-  touch-action: manipulation;
-}
+    .top-mini-action img,
+    .top-mini-action svg {
+      width: 100%;
+      height: 100%;
+      max-width: 36px;
+      max-height: 36px;
+      display: block;
+      object-fit: contain;
+      pointer-events: none;
+    }
+
     .game-flex-wrap {
       width: 100%;
-      flex: 0 0 auto;
-      min-height: 0;
       min-width: 0;
+      min-height: 0;
+      margin-bottom: 4px;
+      flex: 0 0 auto;
       display: flex;
       justify-content: center;
       align-items: center;
-      margin-bottom: 4px;
     }
 
     #gameCanvas {
-      width: 100%;
+      width: min(330px, calc(100vw - 46px));
       max-width: 330px;
-      aspect-ratio: 12/22;
+      aspect-ratio: 12 / 22;
       height: auto;
       max-height: none;
       background: var(--canvas-bg, #180654);
@@ -236,6 +301,135 @@
       display: block;
       margin: 0 auto;
       touch-action: none;
+    }
+
+    @media (max-width: 480px) {
+      .main-content {
+        width: 100vw;
+        max-width: 100vw;
+      }
+
+      .top-bar {
+        max-width: 100vw;
+        padding: calc(var(--safe-top) + 4px) 3px 0 3px;
+      }
+
+      .top-bar-row {
+        grid-template-columns: 32px minmax(0, 1fr) 48px;
+        gap: 6px;
+      }
+
+      .main-title {
+        font-size: 0.99em;
+        letter-spacing: 1.4px;
+      }
+
+      .btn-back {
+        width: 32px;
+        height: 32px;
+      }
+
+      .btn-back img,
+      .btn-icon img {
+        width: 20px;
+        height: 20px;
+      }
+
+      .profile-row {
+        width: 48px;
+        gap: 6px;
+      }
+
+      .wallet-block {
+        gap: 8px;
+        margin-bottom: 4px;
+      }
+
+      .vcoin-icon,
+      .jeton-icon {
+        width: 16px;
+        height: 16px;
+        margin-right: 3px;
+      }
+
+      .vcoins {
+        font-size: 0.97em;
+      }
+
+      .jetons {
+        font-size: 0.88em;
+      }
+
+      .top-canvas-row {
+        grid-template-columns: 62px 104px 62px;
+        column-gap: 5px;
+        padding: 0 4px;
+      }
+
+      .center-top-controls {
+        max-width: 104px;
+        gap: 3px;
+      }
+
+      .top-mini-action {
+        width: 31px;
+        height: 31px;
+      }
+
+      #holdCanvas,
+      #nextCanvas {
+        width: 58px;
+        height: 58px;
+      }
+
+      .side-canvas-block {
+        max-width: 62px;
+      }
+
+      .side-canvas-block label {
+        max-width: 62px;
+        font-size: 0.78rem;
+      }
+
+      #gameCanvas {
+        width: min(330px, calc(100vw - 46px));
+      }
+    }
+
+    @media (max-width: 340px) {
+      .top-canvas-row {
+        grid-template-columns: 56px 92px 56px;
+        column-gap: 3px;
+      }
+
+      .center-top-controls {
+        max-width: 92px;
+        gap: 2px;
+      }
+
+      .top-mini-action {
+        width: 28px;
+        height: 28px;
+      }
+
+      #holdCanvas,
+      #nextCanvas {
+        width: 52px;
+        height: 52px;
+      }
+
+      .side-canvas-block {
+        max-width: 56px;
+      }
+
+      .side-canvas-block label {
+        max-width: 56px;
+        font-size: 0.7rem;
+      }
+
+      #gameCanvas {
+        width: min(320px, calc(100vw - 42px));
+      }
     }
     .score-row {
       margin-top: 8px; font-size: 1.08em; font-weight: 700;

--- a/duel.html
+++ b/duel.html
@@ -21,7 +21,8 @@
       --safe-bottom: env(safe-area-inset-bottom, 0px);
     }
 
-    html, body {
+    html,
+    body {
       margin: 0;
       padding: 0;
       width: 100%;
@@ -35,9 +36,9 @@
     }
 
     body {
+      width: 100%;
       min-height: 100dvh;
       height: 100dvh;
-      width: 100%;
     }
 
     .game-viewport {
@@ -50,13 +51,13 @@
     }
 
     .main-content {
-      display: flex;
-      flex-direction: column;
       width: min(430px, 100vw);
       max-width: 100vw;
       height: auto;
       min-height: 0;
       box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
       align-items: center;
       justify-content: flex-start;
       margin: 0 auto;
@@ -65,7 +66,6 @@
       will-change: transform;
     }
 
-    /* === TOP BAR (comme classic) === */
     .top-bar {
       width: 100%;
       max-width: 430px;
@@ -73,122 +73,363 @@
       display: flex;
       flex-direction: column;
       align-items: stretch;
-      padding: 10px 10px 0 10px;
+      padding: calc(var(--safe-top) + 10px) 10px 0 10px;
       position: relative;
       z-index: 10;
       background: transparent;
+      flex: 0 0 auto;
     }
+
     .top-bar-row {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      justify-content: space-between;
       width: 100%;
+      min-width: 0;
+      display: grid;
+      grid-template-columns: 42px minmax(0, 1fr) 76px;
+      align-items: center;
       gap: 8px;
     }
+
     .btn-back {
-      background: none;
+      width: 42px;
+      height: 42px;
+      padding: 4px;
       border: none;
-      display: flex; align-items: center; justify-content: center;
-      border-radius: 50%; padding: 4px;
+      border-radius: 50%;
+      background: none;
       cursor: pointer;
-      width: 42px; height: 42px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       transition: background 0.15s;
     }
-    .btn-back img { width: 28px; height: 28px; filter: drop-shadow(0 1px 2px #0005);}
+
+    .btn-back img {
+      width: 28px;
+      height: 28px;
+      filter: drop-shadow(0 1px 2px #0005);
+    }
+
     .main-title {
-      flex: 1;
-      font-size: 1.25em; font-weight: 900;
+      min-width: 0;
+      font-size: 1.25em;
+      font-weight: 900;
       color: var(--title-color, #39ff14);
-      letter-spacing: 2px; line-height: 1.1;
+      letter-spacing: 2px;
+      line-height: 1.1;
       text-align: center;
-      white-space: pre-line;
+      white-space: normal;
       word-break: break-word;
       user-select: none;
     }
+
     .profile-row {
+      width: 76px;
+      min-width: 0;
       display: flex;
       flex-direction: row;
+      justify-content: flex-end;
       gap: 8px;
     }
-    .btn-icon img { width: 27px; height: 27px; }
 
-    /* === Wallet identique === */
+    .btn-icon img {
+      width: 27px;
+      height: 27px;
+    }
+
     .wallet-block {
       width: 100%;
+      min-height: 38px;
+      margin: 0 0 7px 0;
       display: flex;
       flex-direction: row;
       align-items: center;
       justify-content: center;
       gap: 18px;
-      margin: 0 0 7px 0;
-      min-height: 38px;
     }
-    .vcoins, .jetons {
+
+    .vcoins,
+    .jetons {
       display: flex;
       align-items: center;
-      font-weight: 700;
       justify-content: center;
+      font-weight: 700;
     }
-    .vcoins { font-size: 1.19em; color: #ffd800; }
-    .jetons { font-size: 1.07em; color: #ffd800; }
-    .vcoin-icon, .jeton-icon {
-      width: 27px; height: 27px;
+
+    .vcoins {
+      font-size: 1.19em;
+      color: #ffd800;
+    }
+
+    .jetons {
+      font-size: 1.07em;
+      color: #ffd800;
+    }
+
+    .vcoin-icon,
+    .jeton-icon {
+      width: 27px;
+      height: 27px;
       vertical-align: middle;
       margin-right: 6px;
     }
 
-    @media (max-width:480px) {
-      .main-content { width: 100vw; max-width: 100vw; }
-      .top-bar { padding: 4px 3px 0 3px; max-width: 100vw; }
-      .main-title { font-size: .99em; }
-      .btn-back { width: 32px; height: 32px; }
-      .btn-back img, .btn-icon img { width: 20px; height: 20px; }
-      .wallet-block { gap: 8px; margin-bottom: 4px; }
-      .vcoin-icon, .jeton-icon { width: 16px; height: 16px; margin-right: 3px; }
-      .vcoins { font-size: .97em; }
-      .jetons { font-size: .88em; }
+    .top-canvas-row {
+      width: min(410px, 100%);
+      max-width: 410px;
+      box-sizing: border-box;
+      display: grid;
+      grid-template-columns: minmax(62px, 78px) minmax(96px, 126px) minmax(62px, 78px);
+      align-items: end;
+      justify-content: center;
+      column-gap: clamp(5px, 2vw, 10px);
+      margin: -30px auto 2px auto;
+      padding: 0 6px;
+      flex: 0 0 auto;
     }
 
-    /* === Panneaux HOLD/NEXT + pause identiques === */
-    .top-canvas-row {
-  width: 100%;
-  max-width: 410px;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-bottom: 2px;
-  margin-top: -30px;
-  flex-shrink: 0;
-}
-    .side-canvas-block { display: flex; flex-direction: column; align-items: center; gap: 2px; }
-    .side-canvas-block label {
-      font-size: 1em; font-weight: 700; margin-bottom: 2px; color: var(--panel-text, #39ff14);
-      text-align: center;
+    .side-canvas-block {
+      width: 100%;
+      min-width: 0;
+      max-width: 78px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 2px;
     }
-    #holdCanvas, #nextCanvas {
+
+    .side-canvas-block label {
+      width: 100%;
+      max-width: 78px;
+      margin-bottom: 2px;
+      font-size: clamp(0.76rem, 3.4vw, 1rem);
+      font-weight: 700;
+      line-height: 1.05;
+      color: var(--panel-text, #39ff14);
+      text-align: center;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    #holdCanvas,
+    #nextCanvas {
+      width: clamp(54px, 18vw, 76px);
+      height: clamp(54px, 18vw, 76px);
+      max-width: 76px;
+      max-height: 76px;
       background: var(--canvas-panel-bg, #161649);
       border: 2px dashed var(--canvas-panel-border, #00fff7);
-      border-radius: 0.4em; box-shadow: 0 2px 7px #39ff1411;
-      display: block; margin: 0 auto;
+      border-radius: 0.4em;
+      box-shadow: 0 2px 7px #39ff1411;
+      display: block;
+      margin: 0 auto;
+      box-sizing: border-box;
     }
 
-    /* === Zone de jeu identique === */
-    .game-flex-wrap {
-      width: 100%; flex: 1 1 0; min-height: 0; min-width: 0;
-      display: flex; justify-content: center; align-items: center;
-      margin-bottom: 4px;
+    #holdCanvas {
+      cursor: pointer;
+      touch-action: manipulation;
     }
+
+    .center-top-controls {
+      width: 100%;
+      min-width: 0;
+      max-width: 126px;
+      box-sizing: border-box;
+      padding-bottom: 5px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: clamp(2px, 1.35vw, 6px);
+      overflow: hidden;
+    }
+
+    .top-mini-action {
+      width: clamp(28px, 8.2vw, 36px);
+      height: clamp(28px, 8.2vw, 36px);
+      min-width: 0;
+      min-height: 0;
+      max-width: 36px;
+      max-height: 36px;
+      padding: 0;
+      margin: 0;
+      border: none;
+      border-radius: 999px;
+      background: transparent;
+      cursor: pointer;
+      touch-action: manipulation;
+      flex: 0 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+    }
+
+    .top-mini-action img,
+    .top-mini-action svg {
+      width: 100%;
+      height: 100%;
+      max-width: 36px;
+      max-height: 36px;
+      display: block;
+      object-fit: contain;
+      pointer-events: none;
+    }
+
+    .game-flex-wrap {
+      width: 100%;
+      min-width: 0;
+      min-height: 0;
+      margin-bottom: 4px;
+      flex: 0 0 auto;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
     #gameCanvas {
-      width: 100%; max-width: 330px; aspect-ratio: 12/22;
-      height: auto; max-height: 100%;
+      width: min(330px, calc(100vw - 46px));
+      max-width: 330px;
+      aspect-ratio: 12 / 22;
+      height: auto;
+      max-height: none;
       background: var(--canvas-bg, #180654);
-      border-radius: 0.4em; box-shadow: 0 6px 32px #39ff1411;
-      display: block; margin: 0 auto;
+      border-radius: 0.4em;
+      box-shadow: 0 6px 32px #39ff1411;
+      display: block;
+      margin: 0 auto;
       touch-action: none;
     }
 
-    /* === Scores identiques === */
+    @media (max-width: 480px) {
+      .main-content {
+        width: 100vw;
+        max-width: 100vw;
+      }
+
+      .top-bar {
+        max-width: 100vw;
+        padding: calc(var(--safe-top) + 4px) 3px 0 3px;
+      }
+
+      .top-bar-row {
+        grid-template-columns: 32px minmax(0, 1fr) 48px;
+        gap: 6px;
+      }
+
+      .main-title {
+        font-size: 0.99em;
+        letter-spacing: 1.4px;
+      }
+
+      .btn-back {
+        width: 32px;
+        height: 32px;
+      }
+
+      .btn-back img,
+      .btn-icon img {
+        width: 20px;
+        height: 20px;
+      }
+
+      .profile-row {
+        width: 48px;
+        gap: 6px;
+      }
+
+      .wallet-block {
+        gap: 8px;
+        margin-bottom: 4px;
+      }
+
+      .vcoin-icon,
+      .jeton-icon {
+        width: 16px;
+        height: 16px;
+        margin-right: 3px;
+      }
+
+      .vcoins {
+        font-size: 0.97em;
+      }
+
+      .jetons {
+        font-size: 0.88em;
+      }
+
+      .top-canvas-row {
+        grid-template-columns: 62px 104px 62px;
+        column-gap: 5px;
+        padding: 0 4px;
+      }
+
+      .center-top-controls {
+        max-width: 104px;
+        gap: 3px;
+      }
+
+      .top-mini-action {
+        width: 31px;
+        height: 31px;
+      }
+
+      #holdCanvas,
+      #nextCanvas {
+        width: 58px;
+        height: 58px;
+      }
+
+      .side-canvas-block {
+        max-width: 62px;
+      }
+
+      .side-canvas-block label {
+        max-width: 62px;
+        font-size: 0.78rem;
+      }
+
+      #gameCanvas {
+        width: min(330px, calc(100vw - 46px));
+      }
+    }
+
+    @media (max-width: 340px) {
+      .top-canvas-row {
+        grid-template-columns: 56px 92px 56px;
+        column-gap: 3px;
+      }
+
+      .center-top-controls {
+        max-width: 92px;
+        gap: 2px;
+      }
+
+      .top-mini-action {
+        width: 28px;
+        height: 28px;
+      }
+
+      #holdCanvas,
+      #nextCanvas {
+        width: 52px;
+        height: 52px;
+      }
+
+      .side-canvas-block {
+        max-width: 56px;
+      }
+
+      .side-canvas-block label {
+        max-width: 56px;
+        font-size: 0.7rem;
+      }
+
+      #gameCanvas {
+        width: min(320px, calc(100vw - 42px));
+      }
+    }
     .score-row {
       margin-top: 8px; font-size: 1.08em; font-weight: 700;
       display: flex; flex-wrap: wrap; justify-content: center; gap: 1em 2em;

--- a/infini.html
+++ b/infini.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>V-Blocks - Infini</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no" />
   <script>
     let currentTheme = localStorage.getItem('themeVBlocks') || 'cyber';
     document.documentElement.setAttribute('data-theme', currentTheme);
@@ -13,34 +13,56 @@
   </script>
   <link rel="stylesheet" href="themes/themes.css" id="theme-style" />
   <style>
-    html, body {
-      margin: 0; padding: 0;
-      width: 100vw; height: 100dvh;
+    :root {
+      --safe-top: env(safe-area-inset-top, 0px);
+      --safe-bottom: env(safe-area-inset-bottom, 0px);
+    }
+
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      min-height: 100dvh;
+      height: 100dvh;
       box-sizing: border-box;
       font-family: 'Quicksand', Arial, sans-serif;
       background: var(--body-bg, #111);
       color: var(--body-color, #ccc);
       overflow: hidden;
-      height: 100%;
     }
+
     body {
-      display: flex; flex-direction: column;
-      min-height: 100dvh; height: 100dvh;
-      width: 100vw;
-      align-items: center; justify-content: flex-start;
+      width: 100%;
+      min-height: 100dvh;
+      height: 100dvh;
     }
+
+    .game-viewport {
+      position: fixed;
+      inset: 0;
+      overflow: hidden;
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+    }
+
     .main-content {
+      width: min(430px, 100vw);
+      max-width: 100vw;
+      height: auto;
+      min-height: 0;
+      box-sizing: border-box;
       display: flex;
       flex-direction: column;
-      width: 100vw;
-      max-width: 430px;
-      height: 100dvh;
-      min-height: 100dvh;
-      box-sizing: border-box;
       align-items: center;
       justify-content: flex-start;
       margin: 0 auto;
+      padding-bottom: calc(var(--safe-bottom) + 14px);
+      transform-origin: top center;
+      will-change: transform;
     }
+
     .top-bar {
       width: 100%;
       max-width: 430px;
@@ -48,129 +70,362 @@
       display: flex;
       flex-direction: column;
       align-items: stretch;
-      padding: 10px 10px 0 10px;
+      padding: calc(var(--safe-top) + 10px) 10px 0 10px;
       position: relative;
       z-index: 10;
       background: transparent;
+      flex: 0 0 auto;
     }
+
     .top-bar-row {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      justify-content: space-between;
       width: 100%;
+      min-width: 0;
+      display: grid;
+      grid-template-columns: 42px minmax(0, 1fr) 76px;
+      align-items: center;
       gap: 8px;
     }
+
     .btn-back {
-      background: none;
+      width: 42px;
+      height: 42px;
+      padding: 4px;
       border: none;
-      display: flex; align-items: center; justify-content: center;
-      border-radius: 50%; padding: 4px;
+      border-radius: 50%;
+      background: none;
       cursor: pointer;
-      width: 42px; height: 42px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       transition: background 0.15s;
     }
-    .btn-back img { width: 28px; height: 28px; filter: drop-shadow(0 1px 2px #0005);}
+
+    .btn-back img {
+      width: 28px;
+      height: 28px;
+      filter: drop-shadow(0 1px 2px #0005);
+    }
+
     .main-title {
-      flex: 1;
-      font-size: 1.25em; font-weight: 900;
+      min-width: 0;
+      font-size: 1.25em;
+      font-weight: 900;
       color: var(--title-color, #39ff14);
-      letter-spacing: 2px; line-height: 1.1;
+      letter-spacing: 2px;
+      line-height: 1.1;
       text-align: center;
-      white-space: pre-line;
+      white-space: normal;
       word-break: break-word;
       user-select: none;
     }
+
     .profile-row {
+      width: 76px;
+      min-width: 0;
       display: flex;
       flex-direction: row;
+      justify-content: flex-end;
       gap: 8px;
     }
-    .btn-icon img { width: 27px; height: 27px; }
+
+    .btn-icon img {
+      width: 27px;
+      height: 27px;
+    }
 
     .wallet-block {
       width: 100%;
+      min-height: 38px;
+      margin: 0 0 7px 0;
       display: flex;
       flex-direction: row;
       align-items: center;
       justify-content: center;
       gap: 18px;
-      margin: 0 0 7px 0;
-      min-height: 38px;
     }
-    .vcoins, .jetons {
+
+    .vcoins,
+    .jetons {
       display: flex;
       align-items: center;
-      font-weight: 700;
       justify-content: center;
+      font-weight: 700;
     }
+
     .vcoins {
       font-size: 1.19em;
       color: #ffd800;
     }
+
     .jetons {
       font-size: 1.07em;
       color: #ffd800;
     }
-    .vcoin-icon, .jeton-icon {
-      width: 27px; height: 27px;
+
+    .vcoin-icon,
+    .jeton-icon {
+      width: 27px;
+      height: 27px;
       vertical-align: middle;
       margin-right: 6px;
     }
 
-    @media (max-width:480px) {
-      .main-content { max-width: 100vw; }
-      .top-bar { padding: 4px 3px 0 3px; max-width: 99vw; }
-      .main-title { font-size: .99em; }
-      .btn-back { width: 32px; height: 32px; }
-      .btn-back img, .btn-icon img { width: 20px; height: 20px; }
-      .wallet-block { gap: 8px; margin-bottom: 4px; }
-      .vcoin-icon, .jeton-icon { width: 16px; height: 16px; margin-right: 3px; }
-      .vcoins { font-size: .97em; }
-      .jetons { font-size: .88em; }
+    .top-canvas-row {
+      width: min(410px, 100%);
+      max-width: 410px;
+      box-sizing: border-box;
+      display: grid;
+      grid-template-columns: minmax(62px, 78px) minmax(96px, 126px) minmax(62px, 78px);
+      align-items: end;
+      justify-content: center;
+      column-gap: clamp(5px, 2vw, 10px);
+      margin: -30px auto 2px auto;
+      padding: 0 6px;
+      flex: 0 0 auto;
     }
-.top-canvas-row {
-  width: 100%;
-  max-width: 410px;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-bottom: 2px;
-  margin-top: -30px;
-  flex-shrink: 0;
-}
-    .side-canvas-block {
-      display: flex; flex-direction: column; align-items: center; gap: 2px;
-    }
-    .side-canvas-block label {
-      font-size: 1em; font-weight: 700; margin-bottom: 2px; color: var(--panel-text, #39ff14);
-      text-align: center;
-    }
-#holdCanvas, #nextCanvas {
-  background: var(--canvas-panel-bg, #161649);
-  border: 2px dashed var(--canvas-panel-border, #00fff7);
-  border-radius: 0.4em;
-  box-shadow: 0 2px 7px #39ff1411;
-  display: block;
-  margin: 0 auto;
-}
 
-#holdCanvas {
-  cursor: pointer;
-  touch-action: manipulation;
-}
-    .game-flex-wrap {
-      width: 100%; flex: 1 1 0; min-height: 0; min-width: 0;
-      display: flex; justify-content: center; align-items: center;
-      margin-bottom: 4px;
+    .side-canvas-block {
+      width: 100%;
+      min-width: 0;
+      max-width: 78px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 2px;
     }
+
+    .side-canvas-block label {
+      width: 100%;
+      max-width: 78px;
+      margin-bottom: 2px;
+      font-size: clamp(0.76rem, 3.4vw, 1rem);
+      font-weight: 700;
+      line-height: 1.05;
+      color: var(--panel-text, #39ff14);
+      text-align: center;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    #holdCanvas,
+    #nextCanvas {
+      width: clamp(54px, 18vw, 76px);
+      height: clamp(54px, 18vw, 76px);
+      max-width: 76px;
+      max-height: 76px;
+      background: var(--canvas-panel-bg, #161649);
+      border: 2px dashed var(--canvas-panel-border, #00fff7);
+      border-radius: 0.4em;
+      box-shadow: 0 2px 7px #39ff1411;
+      display: block;
+      margin: 0 auto;
+      box-sizing: border-box;
+    }
+
+    #holdCanvas {
+      cursor: pointer;
+      touch-action: manipulation;
+    }
+
+    .center-top-controls {
+      width: 100%;
+      min-width: 0;
+      max-width: 126px;
+      box-sizing: border-box;
+      padding-bottom: 5px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: clamp(2px, 1.35vw, 6px);
+      overflow: hidden;
+    }
+
+    .top-mini-action {
+      width: clamp(28px, 8.2vw, 36px);
+      height: clamp(28px, 8.2vw, 36px);
+      min-width: 0;
+      min-height: 0;
+      max-width: 36px;
+      max-height: 36px;
+      padding: 0;
+      margin: 0;
+      border: none;
+      border-radius: 999px;
+      background: transparent;
+      cursor: pointer;
+      touch-action: manipulation;
+      flex: 0 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+    }
+
+    .top-mini-action img,
+    .top-mini-action svg {
+      width: 100%;
+      height: 100%;
+      max-width: 36px;
+      max-height: 36px;
+      display: block;
+      object-fit: contain;
+      pointer-events: none;
+    }
+
+    .game-flex-wrap {
+      width: 100%;
+      min-width: 0;
+      min-height: 0;
+      margin-bottom: 4px;
+      flex: 0 0 auto;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
     #gameCanvas {
-      width: 100%; max-width: 330px; aspect-ratio: 12/22;
-      height: auto; max-height: 100%;
+      width: min(330px, calc(100vw - 46px));
+      max-width: 330px;
+      aspect-ratio: 12 / 22;
+      height: auto;
+      max-height: none;
       background: var(--canvas-bg, #180654);
-      border-radius: 0.4em; box-shadow: 0 6px 32px #39ff1411;
-      display: block; margin: 0 auto;
+      border-radius: 0.4em;
+      box-shadow: 0 6px 32px #39ff1411;
+      display: block;
+      margin: 0 auto;
       touch-action: none;
+    }
+
+    @media (max-width: 480px) {
+      .main-content {
+        width: 100vw;
+        max-width: 100vw;
+      }
+
+      .top-bar {
+        max-width: 100vw;
+        padding: calc(var(--safe-top) + 4px) 3px 0 3px;
+      }
+
+      .top-bar-row {
+        grid-template-columns: 32px minmax(0, 1fr) 48px;
+        gap: 6px;
+      }
+
+      .main-title {
+        font-size: 0.99em;
+        letter-spacing: 1.4px;
+      }
+
+      .btn-back {
+        width: 32px;
+        height: 32px;
+      }
+
+      .btn-back img,
+      .btn-icon img {
+        width: 20px;
+        height: 20px;
+      }
+
+      .profile-row {
+        width: 48px;
+        gap: 6px;
+      }
+
+      .wallet-block {
+        gap: 8px;
+        margin-bottom: 4px;
+      }
+
+      .vcoin-icon,
+      .jeton-icon {
+        width: 16px;
+        height: 16px;
+        margin-right: 3px;
+      }
+
+      .vcoins {
+        font-size: 0.97em;
+      }
+
+      .jetons {
+        font-size: 0.88em;
+      }
+
+      .top-canvas-row {
+        grid-template-columns: 62px 104px 62px;
+        column-gap: 5px;
+        padding: 0 4px;
+      }
+
+      .center-top-controls {
+        max-width: 104px;
+        gap: 3px;
+      }
+
+      .top-mini-action {
+        width: 31px;
+        height: 31px;
+      }
+
+      #holdCanvas,
+      #nextCanvas {
+        width: 58px;
+        height: 58px;
+      }
+
+      .side-canvas-block {
+        max-width: 62px;
+      }
+
+      .side-canvas-block label {
+        max-width: 62px;
+        font-size: 0.78rem;
+      }
+
+      #gameCanvas {
+        width: min(330px, calc(100vw - 46px));
+      }
+    }
+
+    @media (max-width: 340px) {
+      .top-canvas-row {
+        grid-template-columns: 56px 92px 56px;
+        column-gap: 3px;
+      }
+
+      .center-top-controls {
+        max-width: 92px;
+        gap: 2px;
+      }
+
+      .top-mini-action {
+        width: 28px;
+        height: 28px;
+      }
+
+      #holdCanvas,
+      #nextCanvas {
+        width: 52px;
+        height: 52px;
+      }
+
+      .side-canvas-block {
+        max-width: 56px;
+      }
+
+      .side-canvas-block label {
+        max-width: 56px;
+        font-size: 0.7rem;
+      }
+
+      #gameCanvas {
+        width: min(320px, calc(100vw - 42px));
+      }
     }
     .score-row {
       margin-top: 8px; font-size: 1.08em; font-weight: 700;
@@ -305,7 +560,8 @@
 </head>
 <body>
   <canvas id="starfield" style="position:fixed; top:0; left:0; width:100vw; height:100vh; z-index:-1; display:none;"></canvas>
-  <div class="main-content">
+  <div class="game-viewport">
+    <div class="main-content">
     <!-- BARRE TOP -->
     <div class="top-bar">
       <div class="top-bar-row">
@@ -376,6 +632,7 @@
     <div id="controls">
       <button id="music-btn">Musique</button>
       <button onclick="location.reload()">Rejouer</button>
+    </div>
     </div>
   </div>
   <audio id="music" src="assets/sounds/chill.mp3" loop></audio>


### PR DESCRIPTION
### Motivation
- Unifier le comportement responsive et la prise en charge des safe-area insets (notamment iOS) pour les écrans mobiles entre les modes Classique, Infini et Duel.
- Remplacer le CSS fragment hétérogène actuellement présent dans chaque page par un bloc commun, plus robuste et adapté aux devices modernes.
- Corriger la structure HTML manquante dans `infini.html` pour permettre la même mise en page et le même positionnement que dans `classic.html`.

### Description
- Remplacé dans `classic.html`, `infini.html` et `duel.html` le bloc CSS depuis `html, body {` jusqu’à juste avant `.score-row {` par le nouveau bloc fourni incluant `:root` (`--safe-top`/`--safe-bottom`), `.game-viewport`, `.main-content`, règles pour la top-bar, redimensionnement des panels `hold/next`, et media queries mobiles.
- Mis à jour la meta viewport dans `infini.html` pour ajouter `viewport-fit=cover` afin d’activer l’utilisation des safe-area insets sur les iPhone modernes.
- Ajouté dans `infini.html` le wrapper HTML `.game-viewport` autour de `.main-content` et ajusté la fermeture des `div` avant l’élément audio pour rétablir une structure cohérente avec les autres modes.
- Normalisé quelques petites différences de formatage et doublons (:root) rencontrés lors de l’insertion du nouveau bloc CSS pour éviter répétitions.

### Testing
- Recherche automatisée (`rg`) vérifiant la présence/absence des sélecteurs ciblés a confirmé que le bloc CSS a été remplacé dans les trois fichiers et que `viewport-fit=cover` est présent dans `infini.html`.
- Inspection par `git diff`/comparaison des fichiers a permis de valider visuellement les remplacements et la nouvelle structure HTML de `infini.html`.
- Validation que les balises ouvrantes/fermantes supplémentaires ont été ajoutées/ajustées dans `infini.html` pour fermer correctement le wrapper `.game-viewport` avant l’élément audio.
- Tous les contrôles automatisés exécutés pendant la modification ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66a44c2548321a106acc2dde83035)