### PR TITLE
Adjust top canvas layout and top icon controls in classic/infini/duel

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -156,42 +156,79 @@
     .top-canvas-row {
   width: 100%;
   max-width: 410px;
-  display: flex;
+  display: grid;
+  grid-template-columns: 78px 132px 78px;
   justify-content: space-between;
   align-items: flex-end;
   margin-bottom: 2px;
   margin-top: -30px;
   flex-shrink: 0;
+  box-sizing: border-box;
 }
 
     .center-top-controls {
+  width: 132px;
+  max-width: 132px;
+  min-width: 132px;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: clamp(4px, 2.4vw, 10px);
-  min-width: 0;
+  gap: 6px;
   padding-bottom: 6px;
-  flex-shrink: 1;
+  box-sizing: border-box;
+  overflow: visible;
+  flex: 0 0 132px;
 }
 
-    .top-mini-action {
+.top-mini-action {
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  min-height: 40px;
+  max-width: 40px;
+  max-height: 40px;
   background: none;
   border: none;
   cursor: pointer;
-  padding: clamp(1px, 0.6vw, 2px);
+  padding: 2px;
+  margin: 0;
   border-radius: 99px;
   display: flex;
   align-items: center;
   justify-content: center;
   touch-action: manipulation;
-  flex: 0 1 auto;
+  flex: 0 0 40px;
+  box-sizing: border-box;
 }
 
-    .top-mini-action img {
-  width: clamp(30px, 10vw, 36px);
-  height: clamp(30px, 10vw, 36px);
+.top-mini-action img,
+.top-mini-action svg {
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  min-height: 36px;
+  max-width: 36px;
+  max-height: 36px;
   display: block;
   object-fit: contain;
+  pointer-events: none;
+}
+
+@media (max-width: 360px) {
+  .top-canvas-row {
+    grid-template-columns: 72px 132px 72px;
+    padding: 0 2px;
+  }
+
+  #holdCanvas,
+  #nextCanvas {
+    width: 72px;
+    height: 72px;
+  }
+
+  .side-canvas-block label {
+    font-size: 0.86em;
+  }
 }
     .side-canvas-block {
       display: flex; flex-direction: column; align-items: center; gap: 2px;

--- a/duel.html
+++ b/duel.html
@@ -154,12 +154,14 @@
     .top-canvas-row {
   width: 100%;
   max-width: 410px;
-  display: flex;
+  display: grid;
+  grid-template-columns: 78px 132px 78px;
   justify-content: space-between;
   align-items: flex-end;
   margin-bottom: 2px;
   margin-top: -30px;
   flex-shrink: 0;
+  box-sizing: border-box;
 }
     .side-canvas-block { display: flex; flex-direction: column; align-items: center; gap: 2px; }
     .side-canvas-block label {
@@ -312,32 +314,68 @@
 
 
 .center-top-controls {
+  width: 132px;
+  max-width: 132px;
+  min-width: 132px;
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 0;
+  gap: 6px;
   padding-bottom: 6px;
-  flex-shrink: 1;
+  box-sizing: border-box;
+  overflow: visible;
+  flex: 0 0 132px;
 }
 
 .top-mini-action {
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  min-height: 40px;
+  max-width: 40px;
+  max-height: 40px;
   background: none;
   border: none;
   cursor: pointer;
-  padding: clamp(1px, 0.6vw, 2px);
+  padding: 2px;
+  margin: 0;
   border-radius: 99px;
   display: flex;
   align-items: center;
   justify-content: center;
   touch-action: manipulation;
-  flex: 0 1 auto;
+  flex: 0 0 40px;
+  box-sizing: border-box;
 }
 
-.top-mini-action img {
-  width: clamp(30px, 10vw, 36px);
-  height: clamp(30px, 10vw, 36px);
+.top-mini-action img,
+.top-mini-action svg {
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  min-height: 36px;
+  max-width: 36px;
+  max-height: 36px;
   display: block;
   object-fit: contain;
+  pointer-events: none;
+}
+
+@media (max-width: 360px) {
+  .top-canvas-row {
+    grid-template-columns: 72px 132px 72px;
+    padding: 0 2px;
+  }
+
+  #holdCanvas,
+  #nextCanvas {
+    width: 72px;
+    height: 72px;
+  }
+
+  .side-canvas-block label {
+    font-size: 0.86em;
+  }
 }
 </style>
 </head>

--- a/infini.html
+++ b/infini.html
@@ -132,12 +132,14 @@
 .top-canvas-row {
   width: 100%;
   max-width: 410px;
-  display: flex;
+  display: grid;
+  grid-template-columns: 78px 132px 78px;
   justify-content: space-between;
   align-items: flex-end;
   margin-bottom: 2px;
   margin-top: -30px;
   flex-shrink: 0;
+  box-sizing: border-box;
 }
     .side-canvas-block {
       display: flex; flex-direction: column; align-items: center; gap: 2px;
@@ -273,33 +275,68 @@
 
 
 .center-top-controls {
+  width: 132px;
+  max-width: 132px;
+  min-width: 132px;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: clamp(4px, 2.4vw, 10px);
-  min-width: 0;
+  gap: 6px;
   padding-bottom: 6px;
-  flex-shrink: 1;
+  box-sizing: border-box;
+  overflow: visible;
+  flex: 0 0 132px;
 }
 
 .top-mini-action {
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  min-height: 40px;
+  max-width: 40px;
+  max-height: 40px;
   background: none;
   border: none;
   cursor: pointer;
-  padding: clamp(1px, 0.6vw, 2px);
+  padding: 2px;
+  margin: 0;
   border-radius: 99px;
   display: flex;
   align-items: center;
   justify-content: center;
   touch-action: manipulation;
-  flex: 0 1 auto;
+  flex: 0 0 40px;
+  box-sizing: border-box;
 }
 
-.top-mini-action img {
-  width: clamp(30px, 10vw, 36px);
-  height: clamp(30px, 10vw, 36px);
+.top-mini-action img,
+.top-mini-action svg {
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  min-height: 36px;
+  max-width: 36px;
+  max-height: 36px;
   display: block;
   object-fit: contain;
+  pointer-events: none;
+}
+
+@media (max-width: 360px) {
+  .top-canvas-row {
+    grid-template-columns: 72px 132px 72px;
+    padding: 0 2px;
+  }
+
+  #holdCanvas,
+  #nextCanvas {
+    width: 72px;
+    height: 72px;
+  }
+
+  .side-canvas-block label {
+    font-size: 0.86em;
+  }
 }
 </style>
 </head>


### PR DESCRIPTION
### Motivation
- Harmoniser l’alignement des panneaux `HOLD/NEXT` et la zone centrale en passant la barre supérieure en grille pour un positionnement prévisible des colonnes. 
- Normaliser la taille et l’espacement des contrôles d’icônes du haut pour éviter les variations liées aux unités fluides sur petits écrans.

### Description
- Remplace `display: flex` par `display: grid` pour la règle `.top-canvas-row` dans `classic.html`, `infini.html` et `duel.html`, et ajoute `grid-template-columns: 78px 132px 78px` et `box-sizing: border-box` pour un layout fixe en colonnes. 
- Remplace les blocs d’icônes par une nouvelle définition de ` .center-top-controls` et `.top-mini-action` avec largeurs/fixes (132px / 40px) et règles de rendu d’images (`.top-mini-action img, .top-mini-action svg { width: 36px; height: 36px; pointer-events: none; }`).
- Insère immédiatement après ces règles un `@media (max-width: 360px)` qui ajuste `grid-template-columns` à `72px 132px 72px`, redimensionne `#holdCanvas` et `#nextCanvas` à `72px`, et réduit la taille de police des labels de `.side-canvas-block`.
- Les modifications sont limitées aux blocs CSS demandés dans les trois fichiers ciblés et n’affectent rien d’autre.

### Testing
- Vérification de présence/remplacement via recherche de motifs avec `rg` pour `\.top-canvas-row`, `center-top-controls`, `top-mini-action` et la media query, qui a trouvé les occurrences mises à jour avec succès. 
- Exécution du script de transformation (Python) qui a renvoyé un statut `ok` indiquant les remplacements réalisés sans erreur. 
- Inspection des différences appliquées avec `git diff` et revue des fichiers modifiés (`nl`) pour confirmer l’insertion des nouveaux blocs CSS, toutes vérifications automatisées réussies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66ca10ab48321bdf9d4bb05c03dd9)