### PR TITLE
Add responsive top-mini-action icon sizing for very small screens

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -340,6 +340,37 @@
         height: 60px !important;
       }
     }
+
+@media (max-width: 380px) {
+  .top-mini-action img,
+  .top-mini-action svg {
+    width: 30px !important;
+    height: 30px !important;
+    max-width: 30px !important;
+    max-height: 30px !important;
+  }
+}
+
+@media (max-width: 340px) {
+  .top-mini-action img,
+  .top-mini-action svg {
+    width: 28px !important;
+    height: 28px !important;
+    max-width: 28px !important;
+    max-height: 28px !important;
+  }
+}
+
+@media (max-width: 320px) {
+  .top-mini-action img,
+  .top-mini-action svg {
+    width: 25px !important;
+    height: 25px !important;
+    max-width: 25px !important;
+    max-height: 25px !important;
+  }
+}
+
 </style>
 </head>
 <body>

--- a/duel.html
+++ b/duel.html
@@ -339,6 +339,37 @@
   display: block;
   object-fit: contain;
 }
+
+@media (max-width: 380px) {
+  .top-mini-action img,
+  .top-mini-action svg {
+    width: 30px !important;
+    height: 30px !important;
+    max-width: 30px !important;
+    max-height: 30px !important;
+  }
+}
+
+@media (max-width: 340px) {
+  .top-mini-action img,
+  .top-mini-action svg {
+    width: 28px !important;
+    height: 28px !important;
+    max-width: 28px !important;
+    max-height: 28px !important;
+  }
+}
+
+@media (max-width: 320px) {
+  .top-mini-action img,
+  .top-mini-action svg {
+    width: 25px !important;
+    height: 25px !important;
+    max-width: 25px !important;
+    max-height: 25px !important;
+  }
+}
+
 </style>
 </head>
 <body>

--- a/infini.html
+++ b/infini.html
@@ -301,6 +301,37 @@
   display: block;
   object-fit: contain;
 }
+
+@media (max-width: 380px) {
+  .top-mini-action img,
+  .top-mini-action svg {
+    width: 30px !important;
+    height: 30px !important;
+    max-width: 30px !important;
+    max-height: 30px !important;
+  }
+}
+
+@media (max-width: 340px) {
+  .top-mini-action img,
+  .top-mini-action svg {
+    width: 28px !important;
+    height: 28px !important;
+    max-width: 28px !important;
+    max-height: 28px !important;
+  }
+}
+
+@media (max-width: 320px) {
+  .top-mini-action img,
+  .top-mini-action svg {
+    width: 25px !important;
+    height: 25px !important;
+    max-width: 25px !important;
+    max-height: 25px !important;
+  }
+}
+
 </style>
 </head>
 <body>


### PR DESCRIPTION
### Motivation
- Ensure `.top-mini-action` icons are appropriately sized on very small viewports across the game pages to avoid overflow and improve touch targets.

### Description
- Inserted CSS media queries targeting `max-width: 380px`, `340px`, and `320px` immediately before the `</style>` tag in `classic.html`, `infini.html`, and `duel.html`.
- Each breakpoint constrains `.top-mini-action img` and `.top-mini-action svg` to `30px`, `28px`, and `25px` respectively using `!important` and matching `max-width`/`max-height` rules.
- This is a CSS-only change and does not alter HTML structure or JavaScript.

### Testing
- Verified file diffs and insertion location using repository inspection and file printing tools; the new blocks appear just above `</style>` in all three files.
- Confirmed the CSS block was added once per file and not duplicated. 
- All automated inspections completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66f2b60248321bbf481ee26b0b671)