### PR TITLE
Adjust top-mini-action sizing for narrow breakpoints

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -342,32 +342,62 @@
     }
 
 @media (max-width: 380px) {
-  .top-mini-action img,
-  .top-mini-action svg {
+  .top-mini-action {
     width: 30px !important;
     height: 30px !important;
+    min-width: 30px !important;
+    min-height: 30px !important;
     max-width: 30px !important;
     max-height: 30px !important;
+    padding: 0 !important;
+  }
+
+  .top-mini-action img,
+  .top-mini-action svg {
+    width: 26px !important;
+    height: 26px !important;
+    max-width: 26px !important;
+    max-height: 26px !important;
   }
 }
 
 @media (max-width: 340px) {
+  .top-mini-action {
+    width: 27px !important;
+    height: 27px !important;
+    min-width: 27px !important;
+    min-height: 27px !important;
+    max-width: 27px !important;
+    max-height: 27px !important;
+    padding: 0 !important;
+  }
+
   .top-mini-action img,
   .top-mini-action svg {
-    width: 28px !important;
-    height: 28px !important;
-    max-width: 28px !important;
-    max-height: 28px !important;
+    width: 23px !important;
+    height: 23px !important;
+    max-width: 23px !important;
+    max-height: 23px !important;
   }
 }
 
 @media (max-width: 320px) {
+  .top-mini-action {
+    width: 24px !important;
+    height: 24px !important;
+    min-width: 24px !important;
+    min-height: 24px !important;
+    max-width: 24px !important;
+    max-height: 24px !important;
+    padding: 0 !important;
+  }
+
   .top-mini-action img,
   .top-mini-action svg {
-    width: 25px !important;
-    height: 25px !important;
-    max-width: 25px !important;
-    max-height: 25px !important;
+    width: 21px !important;
+    height: 21px !important;
+    max-width: 21px !important;
+    max-height: 21px !important;
   }
 }
 

--- a/duel.html
+++ b/duel.html
@@ -341,32 +341,62 @@
 }
 
 @media (max-width: 380px) {
-  .top-mini-action img,
-  .top-mini-action svg {
+  .top-mini-action {
     width: 30px !important;
     height: 30px !important;
+    min-width: 30px !important;
+    min-height: 30px !important;
     max-width: 30px !important;
     max-height: 30px !important;
+    padding: 0 !important;
+  }
+
+  .top-mini-action img,
+  .top-mini-action svg {
+    width: 26px !important;
+    height: 26px !important;
+    max-width: 26px !important;
+    max-height: 26px !important;
   }
 }
 
 @media (max-width: 340px) {
+  .top-mini-action {
+    width: 27px !important;
+    height: 27px !important;
+    min-width: 27px !important;
+    min-height: 27px !important;
+    max-width: 27px !important;
+    max-height: 27px !important;
+    padding: 0 !important;
+  }
+
   .top-mini-action img,
   .top-mini-action svg {
-    width: 28px !important;
-    height: 28px !important;
-    max-width: 28px !important;
-    max-height: 28px !important;
+    width: 23px !important;
+    height: 23px !important;
+    max-width: 23px !important;
+    max-height: 23px !important;
   }
 }
 
 @media (max-width: 320px) {
+  .top-mini-action {
+    width: 24px !important;
+    height: 24px !important;
+    min-width: 24px !important;
+    min-height: 24px !important;
+    max-width: 24px !important;
+    max-height: 24px !important;
+    padding: 0 !important;
+  }
+
   .top-mini-action img,
   .top-mini-action svg {
-    width: 25px !important;
-    height: 25px !important;
-    max-width: 25px !important;
-    max-height: 25px !important;
+    width: 21px !important;
+    height: 21px !important;
+    max-width: 21px !important;
+    max-height: 21px !important;
   }
 }
 

--- a/infini.html
+++ b/infini.html
@@ -303,32 +303,62 @@
 }
 
 @media (max-width: 380px) {
-  .top-mini-action img,
-  .top-mini-action svg {
+  .top-mini-action {
     width: 30px !important;
     height: 30px !important;
+    min-width: 30px !important;
+    min-height: 30px !important;
     max-width: 30px !important;
     max-height: 30px !important;
+    padding: 0 !important;
+  }
+
+  .top-mini-action img,
+  .top-mini-action svg {
+    width: 26px !important;
+    height: 26px !important;
+    max-width: 26px !important;
+    max-height: 26px !important;
   }
 }
 
 @media (max-width: 340px) {
+  .top-mini-action {
+    width: 27px !important;
+    height: 27px !important;
+    min-width: 27px !important;
+    min-height: 27px !important;
+    max-width: 27px !important;
+    max-height: 27px !important;
+    padding: 0 !important;
+  }
+
   .top-mini-action img,
   .top-mini-action svg {
-    width: 28px !important;
-    height: 28px !important;
-    max-width: 28px !important;
-    max-height: 28px !important;
+    width: 23px !important;
+    height: 23px !important;
+    max-width: 23px !important;
+    max-height: 23px !important;
   }
 }
 
 @media (max-width: 320px) {
+  .top-mini-action {
+    width: 24px !important;
+    height: 24px !important;
+    min-width: 24px !important;
+    min-height: 24px !important;
+    max-width: 24px !important;
+    max-height: 24px !important;
+    padding: 0 !important;
+  }
+
   .top-mini-action img,
   .top-mini-action svg {
-    width: 25px !important;
-    height: 25px !important;
-    max-width: 25px !important;
-    max-height: 25px !important;
+    width: 21px !important;
+    height: 21px !important;
+    max-width: 21px !important;
+    max-height: 21px !important;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Ensure `.top-mini-action` buttons and their icons render consistently on very narrow screens by enforcing explicit box and icon sizing at small breakpoints.
- Prevent visual overflow or inconsistent padding on devices under 380px wide by locking width/height/min/max and removing extra padding.
- Apply the same responsive behavior across the three game templates so the top action buttons behave identically.

### Description
- Replaced the existing responsive block at the end of the CSS (just before `</style>`) in `classic.html`, `infini.html`, and `duel.html` with the requested rules for `@media (max-width: 380px)`, `340px`, and `320px`.
- Added explicit `.top-mini-action` box sizing (width/height/min-width/min-height/max-width/max-height) and `padding: 0 !important;` for each breakpoint.
- Updated `.top-mini-action img` and `.top-mini-action svg` icon sizes to `26px`, `23px`, and `21px` respectively for the `380px`, `340px`, and `320px` breakpoints.
- Ensured the new CSS blocks are placed just before `</style>` in each file so they apply at the intended location.

### Testing
- Confirmed the target files exist with `rg --files | rg 'classic.html|infini.html|duel.html'` and the check succeeded.
- Verified the presence and content of the breakpoint blocks using `rg -n "@media (max-width: (380|340|320)px)|top-mini-action"` per file and the search returned the updated blocks.
- Performed the replacement via a local `python` script and inspected the result with `nl -ba <file> | sed -n` snippets to validate the inserted CSS, and those verifications succeeded; there are no automated unit tests for CSS/HTML in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f67022e9048321b6da3175e8eb096c)