### PR TITLE
Align infini and duel top-bar CSS with Classic safe-area behavior

### DIFF
--- a/duel.html
+++ b/duel.html
@@ -73,7 +73,7 @@
       display: flex;
       flex-direction: column;
       align-items: stretch;
-      padding: 10px 10px 0 10px;
+      padding: calc(var(--safe-top) + 10px) 10px 0 10px;
       position: relative;
       z-index: 10;
       background: transparent;

--- a/infini.html
+++ b/infini.html
@@ -13,50 +13,62 @@
   </script>
   <link rel="stylesheet" href="themes/themes.css" id="theme-style" />
   <style>
-    html, body {
-      margin: 0; padding: 0;
-      width: 100vw; height: 100dvh;
-      box-sizing: border-box;
-      font-family: 'Quicksand', Arial, sans-serif;
-      background: var(--body-bg, #111);
-      color: var(--body-color, #ccc);
-      overflow: hidden;
-      height: 100%;
-    }
-    body {
-      display: flex; flex-direction: column;
-      min-height: 100dvh; height: 100dvh;
-      width: 100vw;
-      align-items: center; justify-content: flex-start;
-    }
-    .game-viewport {
-      position: fixed;
-      inset: 0;
-      overflow: hidden;
-      display: flex;
-      justify-content: center;
-      align-items: flex-start;
-    }
-    .main-content {
-      display: flex;
-      flex-direction: column;
-      width: 100vw;
-      max-width: 430px;
-      height: 100dvh;
-      min-height: 100dvh;
-      box-sizing: border-box;
-      align-items: center;
-      justify-content: flex-start;
-      margin: 0 auto;
-    }
-    .top-bar {
+    :root {
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  min-height: 100dvh;
+  height: 100dvh;
+  box-sizing: border-box;
+  font-family: 'Quicksand', Arial, sans-serif;
+  background: var(--body-bg, #111);
+  color: var(--body-color, #ccc);
+  overflow: hidden;
+}
+
+body {
+  min-height: 100dvh;
+  height: 100dvh;
+  width: 100%;
+}
+
+.game-viewport {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.main-content {
+  display: flex;
+  flex-direction: column;
+  width: min(430px, 100vw);
+  max-width: 100vw;
+  height: auto;
+  min-height: 0;
+  box-sizing: border-box;
+  align-items: center;
+  justify-content: flex-start;
+  margin: 0 auto;
+  padding-bottom: calc(var(--safe-bottom) + 14px);
+  transform-origin: top center;
+  will-change: transform;
+}
+.top-bar {
       width: 100%;
       max-width: 430px;
       box-sizing: border-box;
       display: flex;
       flex-direction: column;
       align-items: stretch;
-      padding: 10px 10px 0 10px;
+      padding: calc(var(--safe-top) + 10px) 10px 0 10px;
       position: relative;
       z-index: 10;
       background: transparent;
@@ -127,8 +139,8 @@
     }
 
     @media (max-width:480px) {
-      .main-content { max-width: 100vw; }
-      .top-bar { padding: 4px 3px 0 3px; max-width: 99vw; }
+      .main-content { width: 100vw; max-width: 100vw; }
+      .top-bar { padding: 4px 3px 0 3px; max-width: 100vw; }
       .main-title { font-size: .99em; }
       .btn-back { width: 32px; height: 32px; }
       .btn-back img, .btn-icon img { width: 20px; height: 20px; }


### PR DESCRIPTION
### Motivation
- Ensure `infini.html` and `duel.html` use the same safe-area-aware top padding as the Classic layout to avoid UI overlap on devices with display insets. 
- Fix mobile layout inconsistencies in `infini.html` where `max-width` and `.main-content` sizing differed from Classic and could produce layout issues on narrow viewports.

### Description
- Replaced the base CSS block at the top of `infini.html` (from `html, body {` up to `.top-bar`) with a safe-area-aware block that adds `:root` variables and adjusts `html`, `body`, `.game-viewport`, and `.main-content` styles. 
- Updated `.top-bar` in `infini.html` to use `padding: calc(var(--safe-top) + 10px) 10px 0 10px;` to respect the device `safe-area-inset-top`. 
- Adjusted the `@media (max-width:480px)` block in `infini.html` so `.main-content` uses `width: 100vw; max-width: 100vw;` and `.top-bar` uses `max-width: 100vw;` (replacing `99vw`). 
- Updated `.top-bar` in `duel.html` to the same safe-area top padding `calc(var(--safe-top) + 10px) 10px 0 10px;` for consistency.

### Testing
- Ran a repository search with `rg` to locate modified patterns and confirm replacements, which completed successfully. 
- Verified diffs with `git diff -- infini.html duel.html` to confirm only the intended files and changes were affected, which succeeded. 
- Committed the changes using `git add` and `git commit -m "Align infini and duel top-bar safe-area CSS"`, and the commit succeeded. 
- Printed file excerpts with `nl -ba infini.html | sed -n '16,170p'` and `nl -ba duel.html | sed -n '60,95p'` to inspect resulting CSS blocks, which matched the requested replacements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7bedabaf88321976c748fe258719d)