### PR TITLE
Update duel end popup flow and add waiting-results translations

### DIFF
--- a/data/AR.json
+++ b/data/AR.json
@@ -134,6 +134,8 @@
   "duel.yourscore": "نتيجتك:",
   "duel.opponentscore": "نتيجة الخصم:",
   "duel.waiting": "بانتظار...",
+  "duel.waiting_results_title": "في انتظار النتائج",
+  "duel.waiting_results_text": "بانتظار نتائج الخصم...",
   "gameover.title": "انتهت اللعبة!",
   "gameover.points": "نقاط مكتسبة!",
   "gameover.tokens": "رصيد الرموز:",

--- a/data/DE.json
+++ b/data/DE.json
@@ -134,6 +134,8 @@
   "duel.yourscore": "Dein Punktestand:",
   "duel.opponentscore": "Gegnerischer Punktestand:",
   "duel.waiting": "Warten...",
+  "duel.waiting_results_title": "Warten auf Ergebnisse",
+  "duel.waiting_results_text": "Warte auf die Ergebnisse deines Gegners...",
   "gameover.title": "Spiel vorbei!",
   "gameover.points": "Punkte gewonnen!",
   "gameover.tokens": "Token-Guthaben:",

--- a/data/EN.json
+++ b/data/EN.json
@@ -134,6 +134,8 @@
   "duel.yourscore": "Your score:",
   "duel.opponentscore": "Opponent score:",
   "duel.waiting": "Waiting...",
+  "duel.waiting_results_title": "Waiting for results",
+  "duel.waiting_results_text": "Waiting for your opponent’s results...",
   "gameover.title": "Game over!",
   "gameover.points": "points won!",
   "gameover.tokens": "Token balance:",

--- a/data/ES-LATAM.json
+++ b/data/ES-LATAM.json
@@ -134,6 +134,8 @@
   "duel.yourscore": "Tu puntuación:",
   "duel.opponentscore": "Puntuación del rival:",
   "duel.waiting": "Esperando...",
+  "duel.waiting_results_title": "Esperando resultados",
+  "duel.waiting_results_text": "Esperando los resultados del rival...",
   "gameover.title": "¡Partida terminada!",
   "gameover.points": "puntos ganados.",
   "gameover.tokens": "Saldo de fichas:",

--- a/data/ES.json
+++ b/data/ES.json
@@ -134,6 +134,8 @@
   "duel.yourscore": "Tu puntuación:",
   "duel.opponentscore": "Puntuación rival:",
   "duel.waiting": "Esperando...",
+  "duel.waiting_results_title": "Esperando resultados",
+  "duel.waiting_results_text": "Esperando los resultados del rival...",
   "gameover.title": "¡Partida terminada!",
   "gameover.points": "puntos ganados!",
   "gameover.tokens": "Saldo de fichas:",

--- a/data/FR.json
+++ b/data/FR.json
@@ -134,6 +134,8 @@
   "duel.yourscore": "Ton score :",
   "duel.opponentscore": "Score adverse :",
   "duel.waiting": "En attente...",
+  "duel.waiting_results_title": "En attente des résultats",
+  "duel.waiting_results_text": "En attente des résultats de l’adversaire...",
   "gameover.title": "Partie terminée !",
   "gameover.points": "points gagnés !",
   "gameover.tokens": "Solde jetons :",

--- a/data/IDN.json
+++ b/data/IDN.json
@@ -134,6 +134,8 @@
   "duel.yourscore": "Skormu:",
   "duel.opponentscore": "Skor lawan:",
   "duel.waiting": "Menunggu...",
+  "duel.waiting_results_title": "Menunggu hasil",
+  "duel.waiting_results_text": "Menunggu hasil dari lawan...",
   "gameover.title": "Permainan selesai!",
   "gameover.points": "poin didapat!",
   "gameover.tokens": "Saldo token:",

--- a/data/IT.json
+++ b/data/IT.json
@@ -134,6 +134,8 @@
   "duel.yourscore": "Il tuo punteggio:",
   "duel.opponentscore": "Punteggio avversario:",
   "duel.waiting": "In attesa...",
+  "duel.waiting_results_title": "In attesa dei risultati",
+  "duel.waiting_results_text": "In attesa dei risultati dell’avversario...",
   "gameover.title": "Partita terminata!",
   "gameover.points": "punti vinti!",
   "gameover.tokens": "Saldo gettoni:",

--- a/data/JP.json
+++ b/data/JP.json
@@ -134,6 +134,8 @@
   "duel.yourscore": "あなたのスコア:",
   "duel.opponentscore": "相手のスコア:",
   "duel.waiting": "待機中...",
+  "duel.waiting_results_title": "結果を待っています",
+  "duel.waiting_results_text": "相手の結果を待っています...",
   "gameover.title": "ゲームオーバー！",
   "gameover.points": "ポイント獲得！",
   "gameover.tokens": "トークン残高:",

--- a/data/KO.json
+++ b/data/KO.json
@@ -134,6 +134,8 @@
   "duel.yourscore": "당신의 점수:",
   "duel.opponentscore": "상대 점수:",
   "duel.waiting": "대기 중...",
+  "duel.waiting_results_title": "결과 대기 중",
+  "duel.waiting_results_text": "상대의 결과를 기다리는 중...",
   "gameover.title": "게임 종료!",
   "gameover.points": "획득 점수!",
   "gameover.tokens": "토큰 잔액:",

--- a/data/NL.json
+++ b/data/NL.json
@@ -134,6 +134,8 @@
   "duel.yourscore": "Jouw score:",
   "duel.opponentscore": "Tegenstander score:",
   "duel.waiting": "Wachten...",
+  "duel.waiting_results_title": "Wachten op resultaten",
+  "duel.waiting_results_text": "Wachten op de resultaten van je tegenstander...",
   "gameover.title": "Spel afgelopen!",
   "gameover.points": "punten gewonnen!",
   "gameover.tokens": "Tokensaldo:",

--- a/data/PT-BR.json
+++ b/data/PT-BR.json
@@ -134,6 +134,8 @@
   "duel.yourscore": "Sua pontuação:",
   "duel.opponentscore": "Pontuação do adversário:",
   "duel.waiting": "Aguardando...",
+  "duel.waiting_results_title": "Aguardando resultados",
+  "duel.waiting_results_text": "Aguardando os resultados do adversário...",
   "gameover.title": "Fim de Jogo!",
   "gameover.points": "pontos ganhos!",
   "gameover.tokens": "Saldo de tokens:",

--- a/data/PT.json
+++ b/data/PT.json
@@ -134,6 +134,8 @@
   "duel.yourscore": "A tua pontuação:",
   "duel.opponentscore": "Pontuação do adversário:",
   "duel.waiting": "A aguardar...",
+  "duel.waiting_results_title": "A aguardar resultados",
+  "duel.waiting_results_text": "A aguardar os resultados do adversário...",
   "gameover.title": "Fim de Jogo!",
   "gameover.points": "pontos ganhos!",
   "gameover.tokens": "Saldo de tokens:",

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -618,163 +618,205 @@ function fillRectThemeSafe(c, px, py, size) {
     }
 
     async function handleDuelEnd(myScore) {
-      const field = (duelPlayerNum === 1) ? 'score1' : 'score2';
-      await sb.from('vblocks_duels').update({ [field]: myScore }).eq('id', duelId);
+  const field = (duelPlayerNum === 1) ? 'score1' : 'score2';
 
-      let tries = 0, otherScore = null;
-      while (tries++ < 40) {
-        let { data } = await sb.from('vblocks_duels').select('*').eq('id', duelId).single();
-        if (duelPlayerNum === 1 && data?.score2 != null) { otherScore = data.score2; break; }
-        if (duelPlayerNum === 2 && data?.score1 != null) { otherScore = data.score1; break; }
-        await new Promise(r => setTimeout(r, 1500));
+  try {
+    await sb.from('vblocks_duels').update({ [field]: myScore }).eq('id', duelId);
+  } catch (err) {
+    console.error('[DUEL] Impossible d’envoyer le score :', err);
+  }
+
+  const rewardAmount = Number(window.REWARD_VCOINS || 300);
+  let rewardClaimed = false;
+
+  const div = document.createElement('div');
+  div.id = 'duel-popup';
+  div.style = 'position:fixed;left:0;top:0;width:100vw;height:100vh;z-index:999999;background:rgba(0,0,0,0.7);display:flex;align-items:center;justify-content:center;color:#fff;font-size:1.2em;';
+
+  div.innerHTML = `
+    <div style="background:#23294a;padding:2em 2em 1.1em 2em;border-radius:1.2em;box-shadow:0 0 12px #39ff1477;text-align:center;min-width:280px;max-width:92vw;">
+      <div id="duel-result-title" style="font-weight:bold;font-size:1.12em;">
+        ${t('duel.waiting_results_title')}
+      </div>
+
+      <div id="duel-result-message" style="margin-top:14px;line-height:1.45;">
+        ${t('duel.waiting_results_text')}
+      </div>
+
+      <div id="duel-result-scores" style="display:none;margin-top:14px;">
+        <div>${t('duel.yourscore')} <b>${myScore}</b></div>
+        <div>${t('duel.opponentscore')} <b id="duel-other-score">${t('duel.waiting')}</b></div>
+      </div>
+
+      <button
+        id="duel-rematch-btn"
+        style="
+          width:100%;
+          margin-top:16px;
+          padding:.9em 1em;
+          border-radius:1em;
+          border:none;
+          background:linear-gradient(180deg,#ff9f2f 0%,#ff7b1e 100%);
+          color:#fff;
+          cursor:pointer;
+          font-weight:800;
+          box-shadow:0 0 14px rgba(255,160,60,.45);
+          display:none;
+        "
+      >
+        ${t('duel.rematch')}
+      </button>
+
+      <button
+        id="duel-reward-vcoins"
+        style="
+          width:100%;
+          margin-top:12px;
+          padding:.85em 1em;
+          border-radius:1em;
+          border:none;
+          background:linear-gradient(180deg,#2f7bff 0%,#1e55d6 100%);
+          color:#fff;
+          cursor:pointer;
+          display:none;
+          align-items:center;
+          justify-content:center;
+          gap:12px;
+          box-shadow:0 0 12px #39f7;
+          font-weight:700;
+        "
+      >
+        <span>${t('end.reward.vcoins')}</span>
+        <span style="display:flex;align-items:center;gap:8px;font-weight:800;">
+          <img src="assets/images/vcoin.webp" alt="" style="width:24px;height:24px;object-fit:contain;">
+          <span>+${rewardAmount} ${t('wallet.vcoins')}</span>
+        </span>
+      </button>
+
+      <button
+        id="duel-back-home"
+        style="margin-top:12px;padding:0.55em 1.2em;font-size:0.95em;border-radius:0.7em;border:none;background:#444;color:#fff;cursor:pointer;"
+      >
+        ${t('button.back')}
+      </button>
+    </div>
+  `;
+
+  document.body.appendChild(div);
+
+  const btnReward = document.getElementById('duel-reward-vcoins');
+  const btnBack = document.getElementById('duel-back-home');
+  const btnRematch = document.getElementById('duel-rematch-btn');
+  const titleEl = document.getElementById('duel-result-title');
+  const messageEl = document.getElementById('duel-result-message');
+  const scoresEl = document.getElementById('duel-result-scores');
+  const otherScoreEl = document.getElementById('duel-other-score');
+
+  if (btnBack) {
+    const goHome = function (e) {
+      e?.preventDefault?.();
+      e?.stopPropagation?.();
+      window.location.replace('index.html');
+    };
+
+    btnBack.addEventListener('click', goHome, { passive: false });
+    btnBack.addEventListener('touchend', goHome, { passive: false });
+    btnBack.style.touchAction = 'manipulation';
+  }
+
+  let tries = 0;
+  let otherScore = null;
+
+  while (tries++ < 40) {
+    try {
+      let { data } = await sb.from('vblocks_duels').select('*').eq('id', duelId).single();
+
+      if (duelPlayerNum === 1 && data?.score2 != null) {
+        otherScore = data.score2;
+        break;
       }
 
-      const rewardAmount = Number(window.REWARD_VCOINS || 300);
-      let rewardClaimed = false;
-
-      const div = document.createElement('div');
-      div.id = 'duel-popup';
-      div.style = 'position:fixed;left:0;top:0;width:100vw;height:100vh;z-index:999999;background:rgba(0,0,0,0.7);display:flex;align-items:center;justify-content:center;color:#fff;font-size:1.2em;';
-
-      div.innerHTML = `
-        <div style="background:#23294a;padding:2em 2em 1.1em 2em;border-radius:1.2em;box-shadow:0 0 12px #39ff1477;text-align:center;min-width:280px;max-width:92vw;">
-          <div style="font-weight:bold;font-size:1.12em;">${t('duel.finished')}</div>
-
-          <div style="margin-top:10px;">${t('duel.yourscore')} <b>${myScore}</b></div>
-          <div>${t('duel.opponentscore')} <b>${otherScore != null ? otherScore : t('duel.waiting')}</b></div>
-
-          <button
-            id="duel-rematch-btn"
-            style="
-              width:100%;
-              margin-top:16px;
-              padding:.9em 1em;
-              border-radius:1em;
-              border:none;
-              background:linear-gradient(180deg,#ff9f2f 0%,#ff7b1e 100%);
-              color:#fff;
-              cursor:pointer;
-              font-weight:800;
-              box-shadow:0 0 14px rgba(255,160,60,.45);
-            "
-          >
-            ${t('duel.rematch')}
-          </button>
-
-          <button
-            id="duel-reward-vcoins"
-            style="
-              width:100%;
-              margin-top:12px;
-              padding:.85em 1em;
-              border-radius:1em;
-              border:none;
-              background:linear-gradient(180deg,#2f7bff 0%,#1e55d6 100%);
-              color:#fff;
-              cursor:pointer;
-              display:flex;
-              align-items:center;
-              justify-content:center;
-              gap:12px;
-              box-shadow:0 0 12px #39f7;
-              font-weight:700;
-            "
-          >
-            <span>${t('end.reward.vcoins')}</span>
-            <span style="display:flex;align-items:center;gap:8px;font-weight:800;">
-              <img src="assets/images/vcoin.webp" alt="" style="width:24px;height:24px;object-fit:contain;">
-              <span>+${rewardAmount} ${t('wallet.vcoins')}</span>
-            </span>
-          </button>
-
-          <button
-            id="duel-back-home"
-            style="margin-top:12px;padding:0.55em 1.2em;font-size:0.95em;border-radius:0.7em;border:none;background:#444;color:#fff;cursor:pointer;"
-          >
-            ${t('button.back')}
-          </button>
-        </div>
-      `;
-
-      document.body.appendChild(div);
-
-      const btnReward = document.getElementById('duel-reward-vcoins');
-      const btnBack = document.getElementById('duel-back-home');
-      const btnRematch = document.getElementById('duel-rematch-btn');
-
-      if (btnRematch?.animate) {
-        btnRematch.animate(
-          [
-            { transform: 'scale(1)', boxShadow: '0 0 14px rgba(255,160,60,.35)' },
-            { transform: 'scale(1.05)', boxShadow: '0 0 24px rgba(255,160,60,.65)' },
-            { transform: 'scale(1)', boxShadow: '0 0 14px rgba(255,160,60,.35)' }
-          ],
-          {
-            duration: 1400,
-            iterations: Infinity,
-            easing: 'ease-in-out'
-          }
-        );
+      if (duelPlayerNum === 2 && data?.score1 != null) {
+        otherScore = data.score1;
+        break;
       }
-
-      if (btnBack) {
-        const goHome = function (e) {
-          e?.preventDefault?.();
-          e?.stopPropagation?.();
-          window.location.replace('index.html');
-        };
-
-        btnBack.addEventListener('click', goHome, { passive: false });
-        btnBack.addEventListener('touchend', goHome, { passive: false });
-        btnBack.style.touchAction = 'manipulation';
-      }
-
-      if (btnRematch) {
-        btnRematch.onclick = async function () {
-          btnRematch.disabled = true;
-          btnRematch.style.opacity = '.7';
-          await requestRematch();
-        };
-      }
-
-      if (btnReward) {
-        btnReward.onclick = async function () {
-          if (rewardClaimed) return;
-
-          btnReward.disabled = true;
-          btnReward.style.opacity = '.7';
-
-          try {
-            const ok = (typeof window.showRewardVcoins === 'function')
-              ? await window.showRewardVcoins()
-              : false;
-
-            if (!ok) {
-              btnReward.disabled = false;
-              btnReward.style.opacity = '1';
-              return;
-            }
-
-            rewardClaimed = true;
-            btnReward.style.display = 'none';
-
-            try {
-              const vcoins = await window.userData?.getVCoins?.();
-              const el = document.getElementById('vcoin-amount');
-              if (el) el.textContent = String(vcoins ?? 0);
-            } catch (_) {}
-          } catch (_) {
-            btnReward.disabled = false;
-            btnReward.style.opacity = '1';
-            alert(t('pub.err'));
-          }
-        };
-      }
-
-      watchIncomingRematchProposal();
+    } catch (err) {
+      console.error('[DUEL] Lecture du score adverse impossible :', err);
     }
 
-    function showEndPopup(points) {
+    await new Promise(r => setTimeout(r, 1500));
+  }
+
+  if (titleEl) titleEl.textContent = t('duel.finished');
+  if (messageEl) messageEl.style.display = 'none';
+  if (scoresEl) scoresEl.style.display = 'block';
+  if (otherScoreEl) otherScoreEl.textContent = otherScore != null ? String(otherScore) : t('duel.waiting');
+
+  if (btnRematch) {
+    btnRematch.style.display = 'block';
+
+    if (btnRematch.animate) {
+      btnRematch.animate(
+        [
+          { transform: 'scale(1)', boxShadow: '0 0 14px rgba(255,160,60,.35)' },
+          { transform: 'scale(1.05)', boxShadow: '0 0 24px rgba(255,160,60,.65)' },
+          { transform: 'scale(1)', boxShadow: '0 0 14px rgba(255,160,60,.35)' }
+        ],
+        {
+          duration: 1400,
+          iterations: Infinity,
+          easing: 'ease-in-out'
+        }
+      );
+    }
+
+    btnRematch.onclick = async function () {
+      btnRematch.disabled = true;
+      btnRematch.style.opacity = '.7';
+      await requestRematch();
+    };
+  }
+
+  if (btnReward) {
+    btnReward.style.display = 'flex';
+
+    btnReward.onclick = async function () {
+      if (rewardClaimed) return;
+
+      btnReward.disabled = true;
+      btnReward.style.opacity = '.7';
+
+      try {
+        const ok = (typeof window.showRewardVcoins === 'function')
+          ? await window.showRewardVcoins()
+          : false;
+
+        if (!ok) {
+          btnReward.disabled = false;
+          btnReward.style.opacity = '1';
+          return;
+        }
+
+        rewardClaimed = true;
+        btnReward.style.display = 'none';
+
+        try {
+          const vcoins = await window.userData?.getVCoins?.();
+          const el = document.getElementById('vcoin-amount');
+          if (el) el.textContent = String(vcoins ?? 0);
+        } catch (_) {}
+      } catch (_) {
+        btnReward.disabled = false;
+        btnReward.style.opacity = '1';
+        alert(t('pub.err'));
+      }
+    };
+  }
+
+  watchIncomingRematchProposal();
+}
+
+function showEndPopup(points) {
       paused = true;
       stopSoftDrop();
       safeRedraw();


### PR DESCRIPTION
### Motivation

- Improve the end-of-duel UX by showing a “waiting for results” state and only revealing the opponent score once available. 
- Ensure the score is reliably written to the backend and provide UI hooks for rematch and reward claiming flows. 
- Add localized strings so the new waiting-state UI is translatable in all supported locales.

### Description

- Replaced the implementation of `async function handleDuelEnd(myScore)` in `js/game_duel.js` to: write the player score to the `vblocks_duels` table with error handling, display a full-screen “waiting for results” popup, poll the duel row until the opponent score is present (or timeout), then reveal both scores and show rematch and reward buttons. 
- The new popup includes a localized title/message using `t('duel.waiting_results_title')` and `t('duel.waiting_results_text')`, a rematch flow that animates the button and calls `requestRematch()`, a reward button that delegates to `window.showRewardVcoins()` and refreshes VCoins display, and a back-home button. 
- Added two new i18n keys (`duel.waiting_results_title` and `duel.waiting_results_text`) immediately after `duel.waiting` across the requested locale files under `data/` (AR, DE, EN, ES, ES-LATAM, FR, IDN, IT, JP, KO, NL, PT, PT-BR).

### Testing

- Confirmed replacement of `handleDuelEnd(myScore)` and presence of the new `t('duel.waiting_results_*')` references in `js/game_duel.js` using `rg` searches; the expected occurrences were found. 
- Inserted the two new keys into each `data/*.json` file with a small script and validated each file contains `"duel.waiting_results_title"` and `"duel.waiting_results_text"` near `"duel.waiting"` using file inspection. 
- Performed a preview of the modified region in `js/game_duel.js` to verify the new popup markup and polling logic are present; validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8643dc16083218e60a301cb998a6e)