### PR TITLE
Variable rewarded vcoin amounts + rewarded-video options in confirm popups

### DIFF
--- a/data/AR.json
+++ b/data/AR.json
@@ -318,5 +318,8 @@
   "rewind.tip.reward": "تفضل، سنمنحك واحدة لتجربتها",
   "rewind.tip.cta": "فهمت",
   "rewind.tip.line1": "يمكنك الضغط على هذا الزر للرجوع 5 قطع إلى الخلف.",
-  "rewind.tip.line2": "يمكنك الضغط على هذا الزر لإزالة آخر 5 أسطر."
+  "rewind.tip.line2": "يمكنك الضغط على هذا الزر لإزالة آخر 5 أسطر.",
+  "end.reward.fixed": "+{amount}",
+  "end.reward.double": "مضاعفة الربح: +{amount}",
+  "common.reward_video": "فيديو بمكافأة"
 }

--- a/data/DE.json
+++ b/data/DE.json
@@ -318,5 +318,8 @@
   "rewind.tip.reward": "Hier, wir geben dir eins zum Ausprobieren",
   "rewind.tip.cta": "Verstanden",
   "rewind.tip.line1": "Du kannst auf diese Taste tippen, um 5 Teile zurückzugehen.",
-  "rewind.tip.line2": "Du kannst auf diese Taste tippen, um die unteren 5 Reihen zu entfernen."
+  "rewind.tip.line2": "Du kannst auf diese Taste tippen, um die unteren 5 Reihen zu entfernen.",
+  "end.reward.fixed": "+{amount}",
+  "end.reward.double": "Gewinn x2: +{amount}",
+  "common.reward_video": "Belohnungsvideo"
 }

--- a/data/EN.json
+++ b/data/EN.json
@@ -318,5 +318,8 @@
   "rewind.tip.reward": "Here, we’re giving you one to try it out",
   "rewind.tip.cta": "Got it",
   "rewind.tip.line1": "You can tap this button to go back 5 pieces.",
-  "rewind.tip.line2": "You can tap this button to remove the bottom 5 lines."
+  "rewind.tip.line2": "You can tap this button to remove the bottom 5 lines.",
+  "end.reward.fixed": "+{amount}",
+  "end.reward.double": "Double reward: +{amount}",
+  "common.reward_video": "Rewarded video"
 }

--- a/data/ES-LATAM.json
+++ b/data/ES-LATAM.json
@@ -318,5 +318,8 @@
   "rewind.tip.reward": "Toma, te damos una para probarlo",
   "rewind.tip.cta": "Entendido",
   "rewind.tip.line1": "Puedes tocar este botón para retroceder 5 piezas.",
-  "rewind.tip.line2": "Puedes tocar este botón para eliminar las 5 líneas de abajo."
+  "rewind.tip.line2": "Puedes tocar este botón para eliminar las 5 líneas de abajo.",
+  "end.reward.fixed": "+{amount}",
+  "end.reward.double": "Ganancia x2: +{amount}",
+  "common.reward_video": "Video recompensado"
 }

--- a/data/ES.json
+++ b/data/ES.json
@@ -318,5 +318,8 @@
   "rewind.tip.reward": "Toma, te damos una para probarlo",
   "rewind.tip.cta": "Entendido",
   "rewind.tip.line1": "Puedes pulsar este botón para retroceder 5 piezas.",
-  "rewind.tip.line2": "Puedes pulsar este botón para eliminar las 5 líneas inferiores."
+  "rewind.tip.line2": "Puedes pulsar este botón para eliminar las 5 líneas inferiores.",
+  "end.reward.fixed": "+{amount}",
+  "end.reward.double": "Ganancia x2: +{amount}",
+  "common.reward_video": "Vídeo recompensado"
 }

--- a/data/FR.json
+++ b/data/FR.json
@@ -318,5 +318,8 @@
   "rewind.tip.reward": "Tiens, on t’en donne un pour essayer",
   "rewind.tip.cta": "Compris",
   "rewind.tip.line1": "Tu peux cliquer sur ce bouton pour revenir 5 pièces en arrière.",
-  "rewind.tip.line2": "Tu peux appuyer sur ce bouton pour supprimer les 5 lignes du bas."
+  "rewind.tip.line2": "Tu peux appuyer sur ce bouton pour supprimer les 5 lignes du bas.",
+  "end.reward.fixed": "+{amount}",
+  "end.reward.double": "Gain x2 : +{amount}",
+  "common.reward_video": "Vidéo récompensée"
 }

--- a/data/IDN.json
+++ b/data/IDN.json
@@ -318,5 +318,8 @@
   "rewind.tip.reward": "Nih, kami kasih satu supaya kamu bisa mencobanya",
   "rewind.tip.cta": "Mengerti",
   "rewind.tip.line1": "Kamu bisa menekan tombol ini untuk mundur 5 keping.",
-  "rewind.tip.line2": "Kamu bisa menekan tombol ini untuk menghapus 5 baris terbawah."
+  "rewind.tip.line2": "Kamu bisa menekan tombol ini untuk menghapus 5 baris terbawah.",
+  "end.reward.fixed": "+{amount}",
+  "end.reward.double": "Hadiah x2: +{amount}",
+  "common.reward_video": "Video berhadiah"
 }

--- a/data/IT.json
+++ b/data/IT.json
@@ -318,5 +318,8 @@
   "rewind.tip.reward": "Ecco, te ne diamo uno per provarlo",
   "rewind.tip.cta": "Capito",
   "rewind.tip.line1": "Puoi premere questo pulsante per tornare indietro di 5 pezzi.",
-  "rewind.tip.line2": "Puoi premere questo pulsante per eliminare le 5 righe inferiori."
+  "rewind.tip.line2": "Puoi premere questo pulsante per eliminare le 5 righe inferiori.",
+  "end.reward.fixed": "+{amount}",
+  "end.reward.double": "Guadagno x2: +{amount}",
+  "common.reward_video": "Video ricompensa"
 }

--- a/data/JP.json
+++ b/data/JP.json
@@ -318,5 +318,8 @@
   "rewind.tip.reward": "お試し用に1つプレゼントします",
   "rewind.tip.cta": "わかった",
   "rewind.tip.line1": "このボタンを押すと5ピース戻れます。",
-  "rewind.tip.line2": "このボタンを押すと下の5ラインを消せます。"
+  "rewind.tip.line2": "このボタンを押すと下の5ラインを消せます。",
+  "end.reward.fixed": "+{amount}",
+  "end.reward.double": "獲得量2倍：+{amount}",
+  "common.reward_video": "リワード動画"
 }

--- a/data/KO.json
+++ b/data/KO.json
@@ -318,5 +318,8 @@
   "rewind.tip.reward": "시험해 볼 수 있도록 하나 드릴게요",
   "rewind.tip.cta": "알겠어요",
   "rewind.tip.line1": "이 버튼을 누르면 5개 조각 전으로 돌아갈 수 있습니다.",
-  "rewind.tip.line2": "이 버튼을 누르면 아래 5줄을 제거할 수 있습니다."
+  "rewind.tip.line2": "이 버튼을 누르면 아래 5줄을 제거할 수 있습니다.",
+  "end.reward.fixed": "+{amount}",
+  "end.reward.double": "보상 2배: +{amount}",
+  "common.reward_video": "보상형 동영상"
 }

--- a/data/NL.json
+++ b/data/NL.json
@@ -318,5 +318,8 @@
   "rewind.tip.reward": "Hier, we geven je er één om het uit te proberen",
   "rewind.tip.cta": "Begrepen",
   "rewind.tip.line1": "Je kunt op deze knop drukken om 5 stukken terug te gaan.",
-  "rewind.tip.line2": "Je kunt op deze knop drukken om de onderste 5 lijnen te verwijderen."
+  "rewind.tip.line2": "Je kunt op deze knop drukken om de onderste 5 lijnen te verwijderen.",
+  "end.reward.fixed": "+{amount}",
+  "end.reward.double": "Winst x2: +{amount}",
+  "common.reward_video": "Beloningsvideo"
 }

--- a/data/PT-BR.json
+++ b/data/PT-BR.json
@@ -318,5 +318,8 @@
   "rewind.tip.reward": "Toma, a gente te dá uma para testar",
   "rewind.tip.cta": "Entendi",
   "rewind.tip.line1": "Você pode tocar neste botão para voltar 5 peças.",
-  "rewind.tip.line2": "Você pode tocar neste botão para remover as 5 linhas de baixo."
+  "rewind.tip.line2": "Você pode tocar neste botão para remover as 5 linhas de baixo.",
+  "end.reward.fixed": "+{amount}",
+  "end.reward.double": "Ganho x2: +{amount}",
+  "common.reward_video": "Vídeo recompensado"
 }

--- a/data/PT.json
+++ b/data/PT.json
@@ -318,5 +318,8 @@
   "rewind.tip.reward": "Toma, damos-te uma para experimentares",
   "rewind.tip.cta": "Percebi",
   "rewind.tip.line1": "Podes tocar neste botão para voltar 5 peças atrás.",
-  "rewind.tip.line2": "Podes tocar neste botão para remover as 5 linhas inferiores."
+  "rewind.tip.line2": "Podes tocar neste botão para remover as 5 linhas inferiores.",
+  "end.reward.fixed": "+{amount}",
+  "end.reward.double": "Ganho x2: +{amount}",
+  "common.reward_video": "Vídeo recompensado"
 }

--- a/js/game.js
+++ b/js/game.js
@@ -961,7 +961,12 @@ overlay.querySelector('#resume-yes').onclick = () => {
         position: fixed; left:0; top:0; width:100vw; height:100vh; z-index:99999;
         background: rgba(0,0,0,0.55); display:flex; align-items:center; justify-content:center;
       `;
-      const rewardAmount = Number(window.REWARD_VCOINS || 300);
+      const baseRewardAmount = Number(window.REWARD_VCOINS || 300);
+      const realWinAmount = Math.max(0, Math.floor(Number(points) || 0));
+      const rewardAmount = realWinAmount > baseRewardAmount ? realWinAmount : baseRewardAmount;
+      const rewardLabel = realWinAmount > baseRewardAmount
+        ? tt('end.reward.double', 'Gain x2 : +{amount}', { amount: rewardAmount })
+        : tt('end.reward.fixed', '+{amount}', { amount: rewardAmount });
       const referralRewardAmount = Number(window.REFERRAL_INVITE_VCOINS || 500);
       if (!recordBeatAlreadyCountedThisRun && points > (Number(runStartHighscore) || 0)) {
         recordBeatAlreadyCountedThisRun = true;
@@ -1039,7 +1044,7 @@ overlay.querySelector('#resume-yes').onclick = () => {
             >
               <span style="display:flex;align-items:center;justify-content:center;gap:10px;font-weight:800;width:100%;">
                 <img src="assets/images/vcoin.webp" alt="" style="width:24px;height:24px;object-fit:contain;">
-                <span>+${rewardAmount}</span>
+                <span>${rewardLabel}</span>
               </span>
             </button>
 
@@ -1342,7 +1347,7 @@ overlay.querySelector('#resume-yes').onclick = () => {
 
           try {
             const ok = (typeof window.showRewardVcoins === 'function')
-              ? await window.showRewardVcoins()
+              ? await window.showRewardVcoins(rewardAmount)
               : false;
 
             if (!ok) {
@@ -1481,7 +1486,11 @@ async function doRewindWithAd() {
     });
 
     resetAds();
-    if (!ok) return;
+    if (!ok) {
+      paused = false;
+      if (!gameOver) requestAnimationFrame(update);
+      return;
+    }
 
     rewindHistoryAndResume(5, 3);
     return;
@@ -1524,18 +1533,22 @@ function showRewindConfirmPopup() {
         )}
       </div>
 
-      <div style="display:flex;gap:10px;justify-content:center;flex-wrap:wrap;">
-        <button id="rewind-confirm-btn" style="padding:.7em 1em;border:none;border-radius:.85em;background:#39f;color:#fff;cursor:pointer;">
-          ${tt(
-            'rewind.confirm',
-            'Utiliser 1 <img src="assets/images/jeton.webp" alt="" style="width:1.35em;height:1.35em;vertical-align:-0.22em;object-fit:contain;">'
-          )}
-        </button>
+      <div style="display:flex;flex-direction:column;gap:10px;justify-content:center;align-items:center;">
+      <button id="rewind-confirm-btn" style="width:100%;padding:.75em 1em;border:none;border-radius:.85em;background:#39f;color:#fff;cursor:pointer;font-weight:800;">
+        ${tt(
+          'rewind.confirm',
+          'Utiliser 1 <img src="assets/images/jeton.webp" alt="" style="width:1.35em;height:1.35em;vertical-align:-0.22em;object-fit:contain;">'
+        )}
+      </button>
 
-        <button id="rewind-cancel-btn" style="padding:.7em 1em;border:none;border-radius:.85em;background:#444;color:#fff;cursor:pointer;">
-          ${tt('common.cancel','Annuler')}
-        </button>
-      </div>
+      <button id="rewind-reward-btn" style="width:100%;padding:.75em 1em;border:none;border-radius:.85em;background:#a73;color:#fff;cursor:pointer;font-weight:800;">
+        ${tt('common.reward_video', 'Vidéo récompensée')}
+      </button>
+
+      <button id="rewind-cancel-btn" style="margin-top:2px;background:transparent;border:none;color:#cfd8ff;cursor:pointer;opacity:.9;">
+        ${tt('common.cancel','Annuler')}
+      </button>
+    </div>
     </div>
   `;
 
@@ -1552,6 +1565,11 @@ function showRewindConfirmPopup() {
   popup.querySelector('#rewind-cancel-btn')?.addEventListener('click', closeOnly);
   popup.addEventListener('click', (e) => {
     if (e.target === popup) closeOnly();
+  });
+
+  popup.querySelector('#rewind-reward-btn')?.addEventListener('click', async () => {
+    popup.remove();
+    await doRewindWithAd();
   });
 
   popup.querySelector('#rewind-confirm-btn')?.addEventListener('click', async () => {
@@ -1703,15 +1721,19 @@ function showClearBottomConfirmPopup() {
         <strong>× 1</strong>
       </div>
 
-      <div style="display:flex;gap:10px;justify-content:center;flex-wrap:wrap;">
-        <button id="clear-bottom-confirm-btn" style="padding:.7em 1em;border:none;border-radius:.85em;background:#39f;color:#fff;cursor:pointer;">
-          ${tt('clear_bottom.confirm', 'Utiliser')}
-        </button>
+      <div style="display:flex;flex-direction:column;gap:10px;justify-content:center;align-items:center;">
+      <button id="clear-bottom-confirm-btn" style="width:100%;padding:.75em 1em;border:none;border-radius:.85em;background:#39f;color:#fff;cursor:pointer;font-weight:800;">
+        ${tt('clear_bottom.confirm', 'Utiliser 1 jeton')}
+      </button>
 
-        <button id="clear-bottom-cancel-btn" style="padding:.7em 1em;border:none;border-radius:.85em;background:#444;color:#fff;cursor:pointer;">
-          ${tt('common.cancel', 'Annuler')}
-        </button>
-      </div>
+      <button id="clear-bottom-reward-btn" style="width:100%;padding:.75em 1em;border:none;border-radius:.85em;background:#a73;color:#fff;cursor:pointer;font-weight:800;">
+        ${tt('common.reward_video', 'Vidéo récompensée')}
+      </button>
+
+      <button id="clear-bottom-cancel-btn" style="margin-top:2px;background:transparent;border:none;color:#cfd8ff;cursor:pointer;opacity:.9;">
+        ${tt('common.cancel', 'Annuler')}
+      </button>
+    </div>
     </div>
   `;
 
@@ -1726,6 +1748,11 @@ function showClearBottomConfirmPopup() {
   popup.querySelector('#clear-bottom-cancel-btn')?.addEventListener('click', closeOnly);
   popup.addEventListener('click', (e) => {
     if (e.target === popup) closeOnly();
+  });
+
+  popup.querySelector('#clear-bottom-reward-btn')?.addEventListener('click', async () => {
+    popup.remove();
+    await doClearBottomWithAd();
   });
 
   popup.querySelector('#clear-bottom-confirm-btn')?.addEventListener('click', async () => {

--- a/js/pub.js
+++ b/js/pub.js
@@ -824,9 +824,14 @@
     });
   }
 
-  async function showRewardVcoins() {
+  async function showRewardVcoins(amount) {
     return new Promise(function(resolve){
-      showRewardedType('vcoin', window.REWARD_VCOINS, function(ok){ resolve(!!ok); });
+      var n = Number(amount);
+      var finalAmount = (Number.isFinite(n) && n > 0)
+        ? Math.floor(n)
+        : Number(window.REWARD_VCOINS || 300);
+
+      showRewardedType('vcoin', finalAmount, function(ok){ resolve(!!ok); });
     });
   }
 


### PR DESCRIPTION
### Motivation
- Allow showing rewarded vcoin ads with a variable amount instead of a fixed global, and prefer giving users the real win amount when higher than the base reward. 
- Provide a rewarded-video alternative to spending a token for the rewind and clear-bottom actions to increase ad-driven UX options. 
- Add localized strings for the dynamic reward labels and the rewarded-video button across all locales.

### Description
- Change `showRewardVcoins` in `js/pub.js` to `showRewardVcoins(amount)` and normalize/fallback the passed `amount` before calling `showRewardedType`. 
- Update end-of-game flow in `js/game.js` to compute `baseRewardAmount`, `realWinAmount`, `rewardAmount` and a localized `rewardLabel`, display the label in the UI and call `showRewardVcoins(rewardAmount)`. 
- Replace the rewind and clear-bottom confirm popups to use a vertical layout with three buttons (token, rewarded-video, cancel), add `#rewind-reward-btn` and `#clear-bottom-reward-btn` click handlers to call `doRewindWithAd()` / `doClearBottomWithAd()`, and adjust ad-failure behavior to properly resume the game loop. 
- Insert three i18n keys (`end.reward.fixed`, `end.reward.double`, `common.reward_video`) into every file under `data/` with the provided translations.

### Testing
- Parsed all `data/*.json` files using `node` to ensure valid JSON and the files parsed successfully. 
- Verified code changes and expected insertions using `rg` searches for `showRewardVcoins(`, `rewardLabel`, `rewind-reward-btn`, `clear-bottom-reward-btn`, `end.reward.fixed` and `common.reward_video`, and all matches were found. 
- Basic repository status checks were performed and showed the modified files staged/committed as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc826425c0832190b08800804feea7)