### PR TITLE
Adjust drop speed progression in solo and duel modes

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -558,7 +558,7 @@ function fillRectThemeSafe(c, px, py, size) {
     let heldPiece = null;
     let holdUsed = false; // conservé pour compat, mais ignoré (échanges illimités)
     let score = 0;
-    let dropInterval = 500;
+    let dropInterval = 800;
     let lastTime = 0;
     let gameOver = false;
     let paused = false;
@@ -1638,7 +1638,7 @@ function clearBottomFiveLinesAsCompleted() {
   }
 
   if (mode === 'classic' || mode === 'duel') {
-    let level = Math.floor(linesCleared / 7);
+    let level = Math.floor(linesCleared / 4);
     if (level >= SPEED_TABLE.length) level = SPEED_TABLE.length - 1;
     dropInterval = SPEED_TABLE[level];
   }
@@ -2075,9 +2075,8 @@ function showNoJetonPopup(opts = {}) {
     }, 200);
 
     const SPEED_TABLE = [
-      800, 720, 630, 550, 470, 380, 300, 220, 130, 100,
-       83,  83,  83,  67,  67,  67,  50,   50,  50,  33,
-       33,  33,  33,  33,  33,  33,  33,  33,  17
+      800, 680, 560, 460, 370, 300, 240, 190, 150, 120,
+      100,  85,  70,  58,  48,  40,  33,  27,  22,  17
     ];
 
 const scoreEl = document.getElementById('score');
@@ -2237,7 +2236,7 @@ if (score > highscoreCloud) {
 
 
         if (mode === 'classic' || mode === 'duel') {
-          let level = Math.floor(linesCleared / 7);
+          let level = Math.floor(linesCleared / 4);
           if (level >= SPEED_TABLE.length) level = SPEED_TABLE.length - 1;
           dropInterval = SPEED_TABLE[level];
         }

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -476,7 +476,7 @@ function fillRectThemeSafe(c, px, py, size) {
     let heldPiece = null;
     let holdUsed = false; // ignoré pour compat — échanges illimités ici
     let score = 0;
-    let dropInterval = 500;
+    let dropInterval = 800;
     let lastTime = 0;
     let gameOver = false;
     let paused = false;
@@ -485,9 +485,8 @@ function fillRectThemeSafe(c, px, py, size) {
     let history = [];
 
     const SPEED_TABLE = [
-      800, 720, 630, 550, 470, 380, 300, 220, 130, 100,
-       83,  83,  83,  67,  67,  67,  50,   50,  50,  33,
-       33,  33,  33,  33,  33,  33,  33,  33,  17
+      800, 680, 560, 460, 370, 300, 240, 190, 150, 120,
+      100,  85,  70,  58,  48,  40,  33,  27,  22,  17
     ];
 
     function updateScoreUI() { if (scoreEl) scoreEl.textContent = String(score); }
@@ -896,7 +895,7 @@ function showEndPopup(points) {
         combo++;
         linesCleared += lines;
         score += computeScore(lines);
-        let level = Math.floor(linesCleared / 7);
+        let level = Math.floor(linesCleared / 4);
         if (level >= SPEED_TABLE.length) level = SPEED_TABLE.length - 1;
         dropInterval = SPEED_TABLE[level];
         updateScoreUI();


### PR DESCRIPTION
### Motivation
- Harmonize and slow initial piece drop speed and tighten level progression to make early gameplay less punishing and increase difficulty ramp.
- Replace the legacy multi-step speed curve with a new 20-level progression for smoother timing steps.
- Increase level-up frequency so levels advance faster based on cleared lines.

### Description
- Set the initial `dropInterval` from `500` to `800` in both `js/game.js` and `js/game_duel.js`.
- Replaced the `SPEED_TABLE` arrays in both files with the new 20-entry progression (`800, 680, 560, 460, 370, 300, 240, 190, 150, 120, 100, 85, 70, 58, 48, 40, 33, 27, 22, 17`).
- Changed level scaling from `Math.floor(linesCleared / 7)` to `Math.floor(linesCleared / 4)` in two places in `js/game.js` and once in `js/game_duel.js` so `dropInterval = SPEED_TABLE[level]` updates earlier.
- Committed the modifications with the message `Adjust drop speed progression in solo and duel modes`.

### Testing
- Ran `rg -n "dropInterval = 500|SPEED_TABLE|linesCleared / 7" js/game.js js/game_duel.js` to locate old patterns and verified replacements succeeded (command completed successfully).
- Inspected the changes with `git diff -- js/game.js js/game_duel.js` and reviewed the updated lines (diff produced as expected).
- Committed the changes with `git commit -m "Adjust drop speed progression in solo and duel modes"` which succeeded.
- No automated unit or integration test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff48595b3083218ab6cf8640091894)