### PR TITLE
Expose interstitial due predicate to game flow

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -2347,7 +2347,8 @@ if (score > highscoreCloud) {
 
         if (
           typeof window.consumeInterstitialAtSafePoint === 'function' &&
-          typeof window.__ads_waiting_choice === 'undefined'
+          typeof window.isInterstitialDueAtSafePoint === 'function' &&
+          window.isInterstitialDueAtSafePoint() === true
         ) {
           const overlay = showPreInterstitialLinesMessage();
 

--- a/js/pub.js
+++ b/js/pub.js
@@ -1164,6 +1164,7 @@
   // Expose global
   // =============================
   window.showInterstitial     = showInterstitial;
+  window.isInterstitialDueAtSafePoint = isInterstitialDueByScreenTime;
   window.consumeInterstitialAtSafePoint = consumeInterstitialAtSafePoint;
   window.showRewardBoutique   = showRewardBoutique;
   window.showRewardVcoins     = showRewardVcoins;


### PR DESCRIPTION
### Motivation
- Permettre à `game.js` de vérifier si une publicité interstitielle est réellement due avant d'afficher l'overlay pré-interstitiel.

### Description
- Expose `isInterstitialDueByScreenTime` sur `window` sous le nom `isInterstitialDueAtSafePoint` dans `js/pub.js`.
- Remplace le gardien `typeof window.__ads_waiting_choice === 'undefined'` par un appel explicite à `window.isInterstitialDueAtSafePoint()` dans `handlePieceLocked()` de `js/game.js` afin de n'afficher l'overlay que si la fonction retourne `true`.
- Conserve le flux existant d'attente (`await waitMs(2500)`), d'affichage/dissimulation d'overlay et d'appel à `consumeInterstitialAtSafePoint()`.

### Testing
- Aucun test automatisé n'a été exécuté sur ces modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14462e4dc48321a8964493c4e837d2)