### PR TITLE
Show pause message when no lines cleared and add i18n key

### DIFF
--- a/data/AR.json
+++ b/data/AR.json
@@ -299,7 +299,6 @@
   "crosspromo.apps.vchronicles.popup2.body": "ثبّت VChronicles وافتحه مرة واحدة ثم ارجع إلى VBlocks للحصول على 1000 VCoins.",
   "crosspromo.apps.vchronicles.popup3.title": "ما زال بإمكانك الربح",
   "crosspromo.apps.vchronicles.popup3.body": "جرّب VChronicles واحصل على 1000 VCoins في VBlocks.",
-
   "crosspromo.apps.vmonster.name": "VMonster",
   "crosspromo.apps.vmonster.store_desc": "ادمج الوحوش وافتح عوالم جديدة وتقدّم في لعبة ممتعة واستراتيجية.",
   "crosspromo.apps.vmonster.popup1.title": "اكتشف VMonster",
@@ -331,5 +330,6 @@
   "rewind.tip.line2": "يمكنك الضغط على هذا الزر لإزالة آخر 5 أسطر.",
   "end.reward.fixed": "+{amount}",
   "end.reward.double": "مضاعفة الربح: +{amount}",
-  "common.reward_video": "فيديو بمكافأة"
+  "common.reward_video": "فيديو بمكافأة",
+  "inter.pause.ready": "استراحة قصيرة قبل المتابعة!"
 }

--- a/data/DE.json
+++ b/data/DE.json
@@ -299,7 +299,6 @@
   "crosspromo.apps.vchronicles.popup2.body": "Installiere VChronicles, öffne es einmal und kehre dann zu VBlocks zurück, um 1000 VCoins zu erhalten.",
   "crosspromo.apps.vchronicles.popup3.title": "Du kannst noch mehr verdienen",
   "crosspromo.apps.vchronicles.popup3.body": "Probiere VChronicles aus und hole dir 1000 VCoins in VBlocks.",
-
   "crosspromo.apps.vmonster.name": "VMonster",
   "crosspromo.apps.vmonster.store_desc": "Verschmelze Monster, schalte neue Welten frei und komme in einem unterhaltsamen Strategiespiel voran.",
   "crosspromo.apps.vmonster.popup1.title": "Entdecke VMonster",
@@ -331,5 +330,6 @@
   "rewind.tip.line2": "Du kannst auf diese Taste tippen, um die unteren 5 Reihen zu entfernen.",
   "end.reward.fixed": "+{amount}",
   "end.reward.double": "Gewinn x2: +{amount}",
-  "common.reward_video": "Belohnungsvideo"
+  "common.reward_video": "Belohnungsvideo",
+  "inter.pause.ready": "Kurze Pause, bevor es weitergeht!"
 }

--- a/data/EN.json
+++ b/data/EN.json
@@ -299,7 +299,6 @@
   "crosspromo.apps.vchronicles.popup2.body": "Install VChronicles, open it once, then come back to VBlocks to collect 1000 VCoins.",
   "crosspromo.apps.vchronicles.popup3.title": "You can still earn more",
   "crosspromo.apps.vchronicles.popup3.body": "Try VChronicles and collect 1000 VCoins on VBlocks.",
-
   "crosspromo.apps.vmonster.name": "VMonster",
   "crosspromo.apps.vmonster.store_desc": "Merge monsters, unlock new worlds and progress through a fun strategic game.",
   "crosspromo.apps.vmonster.popup1.title": "Discover VMonster",
@@ -331,5 +330,6 @@
   "rewind.tip.line2": "You can tap this button to remove the bottom 5 lines.",
   "end.reward.fixed": "+{amount}",
   "end.reward.double": "Double reward: +{amount}",
-  "common.reward_video": "Rewarded video"
+  "common.reward_video": "Rewarded video",
+  "inter.pause.ready": "Quick break before continuing!"
 }

--- a/data/ES-LATAM.json
+++ b/data/ES-LATAM.json
@@ -299,7 +299,6 @@
   "crosspromo.apps.vchronicles.popup2.body": "Instala VChronicles, ábrelo una vez y luego vuelve a VBlocks para recibir 1000 VCoins.",
   "crosspromo.apps.vchronicles.popup3.title": "Todavía puedes ganar más",
   "crosspromo.apps.vchronicles.popup3.body": "Prueba VChronicles y recibe 1000 VCoins en VBlocks.",
-
   "crosspromo.apps.vmonster.name": "VMonster",
   "crosspromo.apps.vmonster.store_desc": "Fusiona monstruos, desbloquea nuevos mundos y avanza en un juego divertido y estratégico.",
   "crosspromo.apps.vmonster.popup1.title": "Descubre VMonster",
@@ -331,5 +330,6 @@
   "rewind.tip.line2": "Puedes tocar este botón para eliminar las 5 líneas de abajo.",
   "end.reward.fixed": "+{amount}",
   "end.reward.double": "Ganancia x2: +{amount}",
-  "common.reward_video": "Video recompensado"
+  "common.reward_video": "Video recompensado",
+  "inter.pause.ready": "¡Pequeña pausa antes de continuar!"
 }

--- a/data/ES.json
+++ b/data/ES.json
@@ -299,7 +299,6 @@
   "crosspromo.apps.vchronicles.popup2.body": "Instala VChronicles, ábrelo una vez y luego vuelve a VBlocks para recibir 1000 VCoins.",
   "crosspromo.apps.vchronicles.popup3.title": "Aún puedes ganar más",
   "crosspromo.apps.vchronicles.popup3.body": "Prueba VChronicles y recibe 1000 VCoins en VBlocks.",
-
   "crosspromo.apps.vmonster.name": "VMonster",
   "crosspromo.apps.vmonster.store_desc": "Fusiona monstruos, desbloquea nuevos mundos y avanza en un juego divertido y estratégico.",
   "crosspromo.apps.vmonster.popup1.title": "Descubre VMonster",
@@ -331,5 +330,6 @@
   "rewind.tip.line2": "Puedes pulsar este botón para eliminar las 5 líneas inferiores.",
   "end.reward.fixed": "+{amount}",
   "end.reward.double": "Ganancia x2: +{amount}",
-  "common.reward_video": "Vídeo recompensado"
+  "common.reward_video": "Vídeo recompensado",
+  "inter.pause.ready": "¡Pequeña pausa antes de continuar!"
 }

--- a/data/FR.json
+++ b/data/FR.json
@@ -299,7 +299,6 @@
   "crosspromo.apps.vchronicles.popup2.body": "Installe VChronicles, ouvre-le une fois, puis reviens sur VBlocks pour récupérer 1000 VCoins.",
   "crosspromo.apps.vchronicles.popup3.title": "Tu peux encore gagner",
   "crosspromo.apps.vchronicles.popup3.body": "Essaie VChronicles et récupère 1000 VCoins sur VBlocks.",
-
   "crosspromo.apps.vmonster.name": "VMonster",
   "crosspromo.apps.vmonster.store_desc": "Fusionne des monstres, débloque des univers et progresse dans un jeu fun et stratégique.",
   "crosspromo.apps.vmonster.popup1.title": "Découvre VMonster",
@@ -331,5 +330,6 @@
   "rewind.tip.line2": "Tu peux appuyer sur ce bouton pour supprimer les 5 lignes du bas.",
   "end.reward.fixed": "+{amount}",
   "end.reward.double": "Gain x2 : +{amount}",
-  "common.reward_video": "Vidéo récompensée"
+  "common.reward_video": "Vidéo récompensée",
+  "inter.pause.ready": "Petite pause avant de continuer !"
 }

--- a/data/IDN.json
+++ b/data/IDN.json
@@ -299,7 +299,6 @@
   "crosspromo.apps.vchronicles.popup2.body": "Instal VChronicles, buka sekali, lalu kembali ke VBlocks untuk mendapatkan 1000 VCoins.",
   "crosspromo.apps.vchronicles.popup3.title": "Kamu masih bisa mendapatkan lebih banyak",
   "crosspromo.apps.vchronicles.popup3.body": "Coba VChronicles dan dapatkan 1000 VCoins di VBlocks.",
-
   "crosspromo.apps.vmonster.name": "VMonster",
   "crosspromo.apps.vmonster.store_desc": "Gabungkan monster, buka dunia baru, dan maju dalam game strategi yang seru.",
   "crosspromo.apps.vmonster.popup1.title": "Temukan VMonster",
@@ -331,5 +330,6 @@
   "rewind.tip.line2": "Kamu bisa menekan tombol ini untuk menghapus 5 baris terbawah.",
   "end.reward.fixed": "+{amount}",
   "end.reward.double": "Hadiah x2: +{amount}",
-  "common.reward_video": "Video berhadiah"
+  "common.reward_video": "Video berhadiah",
+  "inter.pause.ready": "Istirahat sebentar sebelum lanjut!"
 }

--- a/data/IT.json
+++ b/data/IT.json
@@ -299,7 +299,6 @@
   "crosspromo.apps.vchronicles.popup2.body": "Installa VChronicles, aprilo una volta e poi torna su VBlocks per ricevere 1000 VCoins.",
   "crosspromo.apps.vchronicles.popup3.title": "Puoi ancora guadagnare",
   "crosspromo.apps.vchronicles.popup3.body": "Prova VChronicles e ricevi 1000 VCoins su VBlocks.",
-
   "crosspromo.apps.vmonster.name": "VMonster",
   "crosspromo.apps.vmonster.store_desc": "Fondi mostri, sblocca nuovi mondi e avanza in un gioco divertente e strategico.",
   "crosspromo.apps.vmonster.popup1.title": "Scopri VMonster",
@@ -331,5 +330,6 @@
   "rewind.tip.line2": "Puoi premere questo pulsante per eliminare le 5 righe inferiori.",
   "end.reward.fixed": "+{amount}",
   "end.reward.double": "Guadagno x2: +{amount}",
-  "common.reward_video": "Video ricompensa"
+  "common.reward_video": "Video ricompensa",
+  "inter.pause.ready": "Piccola pausa prima di continuare!"
 }

--- a/data/JP.json
+++ b/data/JP.json
@@ -299,7 +299,6 @@
   "crosspromo.apps.vchronicles.popup2.body": "VChronicles をインストールして一度開き、その後 VBlocks に戻って 1000 VCoins を受け取ってください。",
   "crosspromo.apps.vchronicles.popup3.title": "まだ獲得できます",
   "crosspromo.apps.vchronicles.popup3.body": "VChronicles を試して、VBlocks で 1000 VCoins を受け取ってください。",
-
   "crosspromo.apps.vmonster.name": "VMonster",
   "crosspromo.apps.vmonster.store_desc": "モンスターを合体させ、新しいワールドを解放しながら楽しく戦略的に進めるゲームです。",
   "crosspromo.apps.vmonster.popup1.title": "VMonsterを発見",
@@ -331,5 +330,6 @@
   "rewind.tip.line2": "このボタンを押すと下の5ラインを消せます。",
   "end.reward.fixed": "+{amount}",
   "end.reward.double": "獲得量2倍：+{amount}",
-  "common.reward_video": "リワード動画"
+  "common.reward_video": "リワード動画",
+  "inter.pause.ready": "続ける前に少し休憩！"
 }

--- a/data/KO.json
+++ b/data/KO.json
@@ -299,7 +299,6 @@
   "crosspromo.apps.vchronicles.popup2.body": "VChronicles를 설치하고 한 번 실행한 뒤 VBlocks로 돌아와 1000 VCoins를 받으세요.",
   "crosspromo.apps.vchronicles.popup3.title": "아직 더 얻을 수 있어요",
   "crosspromo.apps.vchronicles.popup3.body": "VChronicles를 플레이하고 VBlocks에서 1000 VCoins를 받으세요.",
-
   "crosspromo.apps.vmonster.name": "VMonster",
   "crosspromo.apps.vmonster.store_desc": "몬스터를 합성하고 새로운 월드를 잠금 해제하며 재미있는 전략 게임을 진행하세요.",
   "crosspromo.apps.vmonster.popup1.title": "VMonster 발견하기",
@@ -331,5 +330,6 @@
   "rewind.tip.line2": "이 버튼을 누르면 아래 5줄을 제거할 수 있습니다.",
   "end.reward.fixed": "+{amount}",
   "end.reward.double": "보상 2배: +{amount}",
-  "common.reward_video": "보상형 동영상"
+  "common.reward_video": "보상형 동영상",
+  "inter.pause.ready": "계속하기 전에 잠깐 쉬어가요!"
 }

--- a/data/NL.json
+++ b/data/NL.json
@@ -299,7 +299,6 @@
   "crosspromo.apps.vchronicles.popup2.body": "Installeer VChronicles, open het één keer en keer daarna terug naar VBlocks om 1000 VCoins te ontvangen.",
   "crosspromo.apps.vchronicles.popup3.title": "Je kunt nog steeds verdienen",
   "crosspromo.apps.vchronicles.popup3.body": "Probeer VChronicles en ontvang 1000 VCoins in VBlocks.",
-
   "crosspromo.apps.vmonster.name": "VMonster",
   "crosspromo.apps.vmonster.store_desc": "Voeg monsters samen, ontgrendel nieuwe werelden en groei in een leuk strategisch spel.",
   "crosspromo.apps.vmonster.popup1.title": "Ontdek VMonster",
@@ -331,5 +330,6 @@
   "rewind.tip.line2": "Je kunt op deze knop drukken om de onderste 5 lijnen te verwijderen.",
   "end.reward.fixed": "+{amount}",
   "end.reward.double": "Winst x2: +{amount}",
-  "common.reward_video": "Beloningsvideo"
+  "common.reward_video": "Beloningsvideo",
+  "inter.pause.ready": "Korte pauze voordat je verdergaat!"
 }

--- a/data/PT-BR.json
+++ b/data/PT-BR.json
@@ -299,7 +299,6 @@
   "crosspromo.apps.vchronicles.popup2.body": "Instale VChronicles, abra uma vez e depois volte ao VBlocks para receber 1000 VCoins.",
   "crosspromo.apps.vchronicles.popup3.title": "Você ainda pode ganhar mais",
   "crosspromo.apps.vchronicles.popup3.body": "Teste VChronicles e receba 1000 VCoins no VBlocks.",
-
   "crosspromo.apps.vmonster.name": "VMonster",
   "crosspromo.apps.vmonster.store_desc": "Funda monstros, desbloqueie novos mundos e avance em um jogo divertido e estratégico.",
   "crosspromo.apps.vmonster.popup1.title": "Conheça VMonster",
@@ -331,5 +330,6 @@
   "rewind.tip.line2": "Você pode tocar neste botão para remover as 5 linhas de baixo.",
   "end.reward.fixed": "+{amount}",
   "end.reward.double": "Ganho x2: +{amount}",
-  "common.reward_video": "Vídeo recompensado"
+  "common.reward_video": "Vídeo recompensado",
+  "inter.pause.ready": "Uma pausa rápida antes de continuar!"
 }

--- a/data/PT.json
+++ b/data/PT.json
@@ -299,7 +299,6 @@
   "crosspromo.apps.vchronicles.popup2.body": "Instala VChronicles, abre-o uma vez e depois volta ao VBlocks para receber 1000 VCoins.",
   "crosspromo.apps.vchronicles.popup3.title": "Ainda podes ganhar mais",
   "crosspromo.apps.vchronicles.popup3.body": "Experimenta VChronicles e recebe 1000 VCoins no VBlocks.",
-
   "crosspromo.apps.vmonster.name": "VMonster",
   "crosspromo.apps.vmonster.store_desc": "Funde monstros, desbloqueia novos mundos e progride num jogo divertido e estratégico.",
   "crosspromo.apps.vmonster.popup1.title": "Descobre VMonster",
@@ -331,5 +330,6 @@
   "rewind.tip.line2": "Podes tocar neste botão para remover as 5 linhas inferiores.",
   "end.reward.fixed": "+{amount}",
   "end.reward.double": "Ganho x2: +{amount}",
-  "common.reward_video": "Vídeo recompensado"
+  "common.reward_video": "Vídeo recompensado",
+  "inter.pause.ready": "Pequena pausa antes de continuar!"
 }

--- a/js/game.js
+++ b/js/game.js
@@ -610,7 +610,11 @@ function fillRectThemeSafe(c, px, py, size) {
         animation: preInterPop 220ms ease-out forwards;
       `;
 
-      card.textContent = t('inter.lines.bravo', { count: linesCleared });
+      if (linesCleared > 0) {
+        card.textContent = t('inter.lines.bravo', { count: linesCleared });
+      } else {
+        card.textContent = t('inter.pause.ready');
+      }
 
       overlay.appendChild(card);
       document.body.appendChild(overlay);


### PR DESCRIPTION
### Motivation
- Ensure the pre-interstitial card shows a neutral pause message when no lines were cleared instead of always displaying the "lines cleared" message.

### Description
- Update `showPreInterstitialLinesMessage()` in `js/game.js` to display `t('inter.lines.bravo', { count: linesCleared })` only when `linesCleared > 0` and otherwise show `t('inter.pause.ready')`.
- Add the `inter.pause.ready` translation key to all locale files under `data/` with the requested localized strings.
- Changes touch `js/game.js` and the locale files `data/*.json` for the listed languages.

### Testing
- Ran the update script which parsed and wrote each JSON via `json.loads` and completed successfully.
- Validated JSON formatting with `python -m json.tool data/FR.json` which returned success.
- Confirmed the new logic and keys using `rg -n` to find the updated `js/game.js` lines and `inter.pause.ready` occurrences in `data/*.json`.
- Verified files were staged and committed via `git status --short` and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1574f9f34c83218fec4c62ea9d20c9)