### PR TITLE
Prevent false interstitial messages and normalize lines count

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -610,12 +610,10 @@ function fillRectThemeSafe(c, px, py, size) {
         animation: preInterPop 220ms ease-out forwards;
       `;
 
-      if (linesCleared > 0) {
-        if (linesCleared > 0) {
-  card.textContent = t('inter.lines.bravo', { count: linesCleared });
-} else {
-  card.textContent = t('inter.pause.ready');
-}
+      const safeLinesCleared = Number(linesCleared) || 0;
+
+      if (safeLinesCleared > 0) {
+        card.textContent = t('inter.lines.bravo', { count: safeLinesCleared });
       } else {
         card.textContent = t('inter.pause.ready');
       }

--- a/js/pub.js
+++ b/js/pub.js
@@ -954,6 +954,12 @@
     if (hasBlockingUiForAutoInterstitial()) return false;
     if (getInterstitialScreenVisibleMs() < INTER_ECRAN_VISIBLE_MS) return false;
     if (!canShowInterstitialNow()) return false;
+
+    // Important : on ne dit "pub due" que si une vraie inter peut partir.
+    // Sinon game.js affiche le message, puis aucune pub ne sort.
+    if (!isNative()) return false;
+    if (!AdMob || !AdMob.prepareInterstitial || !AdMob.showInterstitial) return false;
+
     return true;
   }
 
@@ -1073,17 +1079,9 @@
 
     ensureInterstitialCycleStarted();
 
-    var now = Date.now();
-    var needAdByActions = interActionsCount >= INTERSTITIEL_APRES_X_ACTIONS;
-    var needAdByTime = INTERSTITIEL_APRES_MS > 0 && (now - interCycleStartedTs) >= INTERSTITIEL_APRES_MS;
-
-    if (needAdByActions || needAdByTime) {
-      var shown = await showInterstitial();
-      if (shown) {
-        return;
-      }
-    }
-
+    // On ne lance plus d'interstitielle ici.
+    // Les inters doivent passer par le safe point dans game.js :
+    // message tampon → pub → reprise du jeu.
     interActionsCount++;
     localStorage.setItem('inter_actions_count', String(interActionsCount));
   }


### PR DESCRIPTION
### Motivation
- Avoid showing the pre-interstitial message when no real interstitial ad can be displayed to prevent confusing the player. 
- Ensure the lines-cleared message is robust against non-numeric or falsy `linesCleared` values. 
- Centralize interstitial triggering so ads only run from the safe point in the game flow, preventing stray ad launches.

### Description
- In `js/game.js` replaced the duplicated nested `linesCleared` checks with a normalized value `const safeLinesCleared = Number(linesCleared) || 0` and use it to choose between `t('inter.lines.bravo', { count: ... })` and `t('inter.pause.ready')`. 
- In `js/pub.js` updated `isInterstitialDueByScreenTime()` to return `true` only when running in a native context and when `AdMob.prepareInterstitial` and `AdMob.showInterstitial` are available, preventing a pre-message when no ad backend exists. 
- In `js/pub.js` simplified `adsMarkGameLaunched()` to only increment the interstitial action counter and removed direct interstitial launches so interstitials are consumed via the game’s safe point flow.

### Testing
- Ran the automated patch script that updated `js/game.js` and `js/pub.js`, which completed successfully and printed `patched`. 
- Inspected the resulting diffs for `js/game.js` and `js/pub.js` and confirmed the intended replacements appear in the files. 
- Printed file excerpts with `nl`/`sed` to verify the new code blocks are present and located as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15838bf2f08321baed1ade4ae5cd42)