### PR TITLE
Refactor interstitial safe-point pre-show flow

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -2351,26 +2351,23 @@ if (score > highscoreCloud) {
 
         safeRedraw();
 
-        if (
-          typeof window.consumeInterstitialAtSafePoint === 'function' &&
-          typeof window.isInterstitialDueAtSafePoint === 'function' &&
-          window.isInterstitialDueAtSafePoint() === true
-        ) {
-          const overlay = showPreInterstitialLinesMessage();
-
-          await waitMs(2500);
-
-          hidePreInterstitialLinesMessage();
-
+        if (typeof window.consumeInterstitialAtSafePoint === 'function') {
           try {
-            const shown = await window.consumeInterstitialAtSafePoint();
+            const shown = await window.consumeInterstitialAtSafePoint(async function () {
+              const overlay = showPreInterstitialLinesMessage();
+
+              try {
+                await waitMs(2500);
+              } finally {
+                hidePreInterstitialLinesMessage();
+                if (overlay && overlay.isConnected) overlay.remove();
+              }
+            });
 
             if (shown) {
               lastTime = performance.now();
             }
           } catch (_) {}
-
-          if (overlay && overlay.isConnected) overlay.remove();
         }
 
         setTimeout(() => { maybeShowRewindTutorialPopup(); }, 120);

--- a/js/pub.js
+++ b/js/pub.js
@@ -969,10 +969,10 @@
     return false;
   }
 
-  async function consumeInterstitialAtSafePoint() {
+  async function consumeInterstitialAtSafePoint(beforeShow) {
     if (!isInterstitialDueByScreenTime()) return false;
 
-    var shown = await showInterstitial();
+    var shown = await showInterstitial(beforeShow);
 
     if (shown) {
       resetInterstitialScreenClock();
@@ -1003,25 +1003,30 @@
     resetInterstitialScreenClock();
   }
 
-  async function showInterstitial() {
+  async function showInterstitial(beforeShow) {
     try {
       var path = (location.pathname || '').toLowerCase();
       if (path.endsWith('/duel.html')) return false;
     } catch (_) {}
 
     var watchdog = null;
+
     try {
       if (await hasNoAds()) { return false; }
       if (!isNative()) { return false; }
+
       if (!AdMob || !AdMob.prepareInterstitial || !AdMob.showInterstitial) {
         return false;
       }
+
       if (!canShowInterstitialNow()) { return false; }
       if (__showLock) { return false; }
 
       var adConsent = await ensureCanRequestAds();
       var adId = AD_UNIT_ID_INTERSTITIEL;
 
+      // On prépare d'abord la vraie interstitielle.
+      // Si cette étape échoue, aucun message tampon ne s'affiche.
       await AdMob.prepareInterstitial({
         adId: adId,
         requestOptions: buildAdMobRequestOptions(adConsent.limited)
@@ -1029,6 +1034,16 @@
 
       __showLock = true;
       currentAdKind = "interstitial";
+
+      // Le message tampon est affiché seulement après préparation réussie.
+      if (typeof beforeShow === 'function') {
+        try {
+          await beforeShow();
+        } catch (_) {
+          return false;
+        }
+      }
+
       preShowAdCleanup();
 
       watchdog = setTimeout(function(){
@@ -1044,24 +1059,39 @@
 
       if (res !== false) {
         markInterstitialShownNow();
+
         try {
           window.VRAnalytics?.logEvent?.('interstitial_show', {
             page: window.VRAnalytics?.getPageName?.() || 'unknown'
           });
         } catch (_) {}
+
         setTimeout(function(){
-          AdMob.prepareInterstitial({ adId: adId, requestOptions: buildAdMobRequestOptions(true) }).catch(function(){});
+          AdMob.prepareInterstitial({
+            adId: adId,
+            requestOptions: buildAdMobRequestOptions(true)
+          }).catch(function(){});
         }, 1200);
+
         return true;
       }
+
       return false;
     } catch (_e) {
       try {
-        AdMob.prepareInterstitial({ adId: AD_UNIT_ID_INTERSTITIEL, requestOptions: buildAdMobRequestOptions(true) }).catch(function(){});
+        AdMob.prepareInterstitial({
+          adId: AD_UNIT_ID_INTERSTITIEL,
+          requestOptions: buildAdMobRequestOptions(true)
+        }).catch(function(){});
       } catch(_) {}
+
       return false;
     } finally {
-      if (watchdog) { clearTimeout(watchdog); watchdog = null; }
+      if (watchdog) {
+        clearTimeout(watchdog);
+        watchdog = null;
+      }
+
       __showLock = false;
       currentAdKind = null;
       postAdCleanup();


### PR DESCRIPTION
### Motivation
- Éviter d’afficher un message tampon quand l’interstitielle n’est pas réellement prête en scindant la préparation d’annonce et l’affichage du message.
- Centraliser le comportement pré-affichage au point sûr pour garantir le nettoyage de l’overlay même en cas d’erreur.

### Description
- Dans `js/game.js` `handlePieceLocked()` passe maintenant un callback `beforeShow` à `window.consumeInterstitialAtSafePoint` pour afficher l’overlay et attendre via `waitMs` avec nettoyage dans un `finally`.
- Dans `js/pub.js` la fonction `showInterstitial` accepte un paramètre optionnel `beforeShow`, prépare d’abord l’interstitielle via `AdMob.prepareInterstitial`, puis exécute `beforeShow` uniquement après préparation réussie.
- Dans `js/pub.js` la fonction `consumeInterstitialAtSafePoint` accepte désormais `beforeShow` et le transmet à `showInterstitial` tout en conservant le reset de l’horloge si l’annonce a été affichée.
- Les mécanismes existants de verrou (`__showLock`), watchdog et cleanup (`preShowAdCleanup`/`postAdCleanup`) sont préservés.

### Testing
- Le diff a été inspecté avec `git diff` et les modifications ont été ajoutées et commitées avec `git add`/`git commit`, ce qui a réussi.
- Aucune suite de tests automatisés runtime n’a été exécutée dans cette session; seuls les contrôles de diff/commit ont été réalisés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1586e29d248321a064a77f2a205979)