### PR TITLE
Queue interstitial display requests and consume them at game safe points

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -569,6 +569,7 @@ function fillRectThemeSafe(c, px, py, size) {
     let rewindTutorialShownThisRun = false;
     let rewindTutorialBusy = false;
     let pieceLockTransitionRunning = false;
+    let interstitialSafePointRequested = false;
 
     function waitMs(ms) {
       return new Promise(resolve => setTimeout(resolve, ms));
@@ -640,6 +641,10 @@ function fillRectThemeSafe(c, px, py, size) {
       const overlay = document.getElementById('pre-interstitial-lines-message');
       if (overlay) overlay.remove();
     }
+
+    window.addEventListener('vblocks:interstitial-safe-point-requested', function () {
+      interstitialSafePointRequested = true;
+    });
 
     // revive ramp
     let reviveRampActive = false;
@@ -2351,7 +2356,13 @@ if (score > highscoreCloud) {
 
         safeRedraw();
 
-        if (typeof window.consumeInterstitialAtSafePoint === 'function') {
+        if (
+          (interstitialSafePointRequested || window.__vblocksInterstitialSafePointRequested === true) &&
+          typeof window.consumeInterstitialAtSafePoint === 'function'
+        ) {
+          interstitialSafePointRequested = false;
+          window.__vblocksInterstitialSafePointRequested = false;
+
           try {
             const shown = await window.consumeInterstitialAtSafePoint(async function () {
               const overlay = showPreInterstitialLinesMessage();

--- a/js/pub.js
+++ b/js/pub.js
@@ -63,6 +63,9 @@
   var interScreenVisibleMs = parseInt(localStorage.getItem('inter_screen_visible_ms') || '0', 10);
   var interScreenLastResumeTs = parseInt(localStorage.getItem('inter_screen_last_resume_ts') || '0', 10);
   var interScreenTimer = null;
+  var interstitialSafePointPending = false;
+
+  window.__vblocksInterstitialSafePointRequested = false;
 
   if (!Number.isFinite(interActionsCount)) interActionsCount = 0;
   if (!Number.isFinite(lastInterTs)) lastInterTs = 0;
@@ -964,18 +967,36 @@
   }
 
   async function maybeShowInterstitialByScreenTime() {
-    // En jeu, on ne coupe plus directement.
-    // La pub attend le safe point dans game.js.
-    return false;
+    if (interstitialSafePointPending) return false;
+    if (!isInterstitialDueByScreenTime()) return false;
+
+    interstitialSafePointPending = true;
+    window.__vblocksInterstitialSafePointRequested = true;
+
+    try {
+      window.dispatchEvent(new CustomEvent('vblocks:interstitial-safe-point-requested'));
+    } catch (_) {}
+
+    return true;
   }
 
   async function consumeInterstitialAtSafePoint(beforeShow) {
-    if (!isInterstitialDueByScreenTime()) return false;
+    if (!interstitialSafePointPending && window.__vblocksInterstitialSafePointRequested !== true) {
+      return false;
+    }
+
+    interstitialSafePointPending = false;
+    window.__vblocksInterstitialSafePointRequested = false;
+
+    if (!isInterstitialDueByScreenTime()) {
+      return false;
+    }
 
     var shown = await showInterstitial(beforeShow);
 
+    resetInterstitialScreenClock();
+
     if (shown) {
-      resetInterstitialScreenClock();
       return true;
     }
 
@@ -1192,7 +1213,9 @@
   // Expose global
   // =============================
   window.showInterstitial     = showInterstitial;
-  window.isInterstitialDueAtSafePoint = isInterstitialDueByScreenTime;
+  window.isInterstitialDueAtSafePoint = function () {
+    return interstitialSafePointPending || window.__vblocksInterstitialSafePointRequested === true;
+  };
   window.consumeInterstitialAtSafePoint = consumeInterstitialAtSafePoint;
   window.showRewardBoutique   = showRewardBoutique;
   window.showRewardVcoins     = showRewardVcoins;


### PR DESCRIPTION
### Motivation
- Éviter que l’ads manager essaie d’afficher une interstitielle à chaque verrouillage de pièce en jeu et découpler l’éligibilité temporelle (`screen time`) de l’exécution effective en jeu.
- Permettre à la logique de jeu de décider du meilleur « safe point » pour afficher une pub quand elle est due.

### Description
- Ajout d’un flag `interstitialSafePointPending` et d’un flag global `window.__vblocksInterstitialSafePointRequested` dans `js/pub.js` pour mémoriser une demande d’interstitielle en attente de safe point.
- Remplacement de `maybeShowInterstitialByScreenTime()` pour qu’elle mette la demande en attente et émette l’événement `vblocks:interstitial-safe-point-requested` au lieu d’afficher directement.
- Modification de `consumeInterstitialAtSafePoint()` pour qu’elle vérifie/consomme et remette à zéro les flags de demande avant d’essayer d’afficher, et appelle `resetInterstitialScreenClock()` après la tentative d’affichage.
- Exposition de `window.isInterstitialDueAtSafePoint` comme une vérification des flags en attente plutôt que de `isInterstitialDueByScreenTime()`.
- Ajout côté jeu dans `js/game.js` d’un flag local `interstitialSafePointRequested`, d’un listener pour `vblocks:interstitial-safe-point-requested` et mise à jour de `handlePieceLocked()` pour n’appeler `consumeInterstitialAtSafePoint` que si une demande est présente, en réinitialisant d’abord les flags locaux/globaux.

### Testing
- Recherches et inspections de fichiers avec `rg` et `sed` pour valider les emplacements ciblés, toutes réussies.
- Modifications appliquées aux fichiers `js/pub.js` et `js/game.js` et vérifiées avec `git diff`, succès.
- Changements ajoutés et commités avec `git add` + `git commit`, commit créé successfully.
- PR créé via l’outil `make_pr`, opération réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a158df3e064832195988a04126d665d)