### PR TITLE
Make .top-canvas-row bottom spacing responsive in classic/infini/duel

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -159,7 +159,7 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  margin-bottom: 2px;
+  margin-bottom: clamp(10px, 1.8vh, 16px);
   margin-top: -30px;
   flex-shrink: 0;
 }

--- a/duel.html
+++ b/duel.html
@@ -157,7 +157,7 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  margin-bottom: 2px;
+  margin-bottom: clamp(10px, 1.8vh, 16px);
   margin-top: -30px;
   flex-shrink: 0;
 }

--- a/infini.html
+++ b/infini.html
@@ -155,7 +155,7 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  margin-bottom: 2px;
+  margin-bottom: clamp(10px, 1.8vh, 16px);
   margin-top: -30px;
   flex-shrink: 0;
 }


### PR DESCRIPTION
### Motivation
- Improve vertical spacing consistency across small and large viewports by replacing a fixed small bottom margin with a responsive `clamp()` value for the `.top-canvas-row` block.

### Description
- Replaced `margin-bottom: 2px;` with `margin-bottom: clamp(10px, 1.8vh, 16px);` inside the `.top-canvas-row` CSS block.
- Applied the change in `classic.html`, `infini.html`, and `duel.html` and left all other properties in the block unchanged.

### Testing
- Ran `rg -n "\.top-canvas-row \{" classic.html infini.html duel.html` to locate occurrences and confirmed matches (succeeded).
- Executed the targeted replacement via a Python script to update the three files and confirmed the replacements completed (succeeded).
- Verified the resulting diffs show only the intended `margin-bottom` change in the three files (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15b23ee320832199f14e750fe29c7d)