### PR TITLE
Adjust canvas sizing and tablet UI scaling across game modes

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -64,6 +64,7 @@
       padding-bottom: calc(var(--safe-bottom) + 14px);
       transform-origin: top center;
       will-change: transform;
+      --vblocks-ui-scale: 1;
     }
     .top-bar {
       width: 100%;
@@ -91,13 +92,18 @@
       display: flex; align-items: center; justify-content: center;
       border-radius: 50%; padding: 4px;
       cursor: pointer;
-      width: 42px; height: 42px;
+      width: clamp(32px, calc(42px * var(--vblocks-ui-scale)), 56px);
+      height: clamp(32px, calc(42px * var(--vblocks-ui-scale)), 56px);
       transition: background 0.15s;
     }
-    .btn-back img { width: 28px; height: 28px; filter: drop-shadow(0 1px 2px #0005);}
+    .btn-back img {
+      width: clamp(20px, calc(28px * var(--vblocks-ui-scale)), 38px);
+      height: clamp(20px, calc(28px * var(--vblocks-ui-scale)), 38px);
+      filter: drop-shadow(0 1px 2px #0005);
+    }
     .main-title {
       flex: 1;
-      font-size: 1.25em; font-weight: 900;
+      font-size: clamp(0.98rem, calc(1.25rem * var(--vblocks-ui-scale)), 1.55rem); font-weight: 900;
       color: var(--title-color, #39ff14);
       letter-spacing: 2px; line-height: 1.1;
       text-align: center;
@@ -110,7 +116,10 @@
       flex-direction: row;
       gap: 8px;
     }
-    .btn-icon img { width: 27px; height: 27px; }
+    .btn-icon img {
+      width: clamp(20px, calc(27px * var(--vblocks-ui-scale)), 38px);
+      height: clamp(20px, calc(27px * var(--vblocks-ui-scale)), 38px);
+    }
 
     .wallet-block {
       width: 100%;
@@ -188,8 +197,8 @@
 }
 
     .top-mini-action img {
-  width: clamp(21px, 7vw, 25px);
-  height: clamp(21px, 7vw, 25px);
+  width: clamp(20px, calc(25px * var(--vblocks-ui-scale)), 38px);
+  height: clamp(20px, calc(25px * var(--vblocks-ui-scale)), 38px);
   display: block;
   object-fit: contain;
 }
@@ -211,7 +220,10 @@
       display: flex; flex-direction: column; align-items: center; gap: 2px;
     }
     .side-canvas-block label {
-      font-size: 1em; font-weight: 700; margin-bottom: 2px; color: var(--panel-text, #39ff14);
+      font-size: clamp(0.82rem, calc(1rem * var(--vblocks-ui-scale)), 1.2rem);
+      font-weight: 700;
+      margin-bottom: 2px;
+      color: var(--panel-text, #39ff14);
       text-align: center;
     }
 #holdCanvas, #nextCanvas {
@@ -239,8 +251,8 @@
     }
 
     #gameCanvas {
-      width: 100%;
-      max-width: 330px;
+      width: min(100%, 330px);
+      max-width: none;
       aspect-ratio: 12/22;
       height: auto;
       max-height: none;
@@ -252,7 +264,9 @@
       touch-action: none;
     }
     .score-row {
-      margin-top: 8px; font-size: 1.08em; font-weight: 700;
+      margin-top: clamp(7px, calc(8px * var(--vblocks-ui-scale)), 12px);
+      font-size: clamp(0.92rem, calc(1.08rem * var(--vblocks-ui-scale)), 1.28rem);
+      font-weight: 700;
       display: flex; flex-wrap: wrap; justify-content: center; gap: 1em 2em;
       color: var(--score-color, #39ff14);
       width: 97vw; max-width: 430px; letter-spacing: 0.6px; flex-shrink: 0;
@@ -274,7 +288,8 @@
       background: var(--btn-bg, #161649);
       color: var(--btn-color, #39ff14);
       font-weight: 700; border: none; border-radius: 1.1em;
-      padding: 0.68em 1.4em; font-size: 1.03em;
+      padding: clamp(0.58em, calc(0.68em * var(--vblocks-ui-scale)), 0.82em) clamp(1.15em, calc(1.4em * var(--vblocks-ui-scale)), 1.75em);
+      font-size: clamp(0.92rem, calc(1.03rem * var(--vblocks-ui-scale)), 1.2rem);
       cursor: pointer; box-shadow: 0 1.5px 7px #00fff738;
     }
     #controls button:active {
@@ -282,48 +297,58 @@
       color: var(--btn-hover-color, #fff);
     }
     /* ===== Tablettes portrait et grands écrans tactiles ===== */
-    @media (min-width: 701px) and (max-width: 1200px) and (min-height: 900px) {
-      .main-content {
-        width: min(720px, calc(100vw - 32px)) !important;
-        max-width: min(720px, calc(100vw - 32px)) !important;
-      }
+@media (min-width: 701px) and (max-width: 1200px) and (min-height: 900px) {
+  .main-content {
+    width: min(760px, calc(100vw - 32px)) !important;
+    max-width: min(760px, calc(100vw - 32px)) !important;
+  }
 
-      .top-bar {
-        width: 100% !important;
-        max-width: none !important;
-        padding-left: 0 !important;
-        padding-right: 0 !important;
-      }
+  .top-bar {
+    width: 100% !important;
+    max-width: none !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
 
-      .top-canvas-row {
-        width: min(100%, 700px) !important;
-        max-width: 700px !important;
-        margin-top: -12px !important;
-      }
+  .top-canvas-row {
+    width: min(100%, 760px) !important;
+    max-width: 760px !important;
+    margin-top: -12px !important;
+    margin-bottom: clamp(12px, 1.4vh, 20px) !important;
+  }
 
-      #gameCanvas {
-        width: 100% !important;
-        max-width: 520px !important;
-      }
+  .score-row {
+    width: 100% !important;
+    max-width: none !important;
+  }
+}
 
-      .score-row {
-        width: 100% !important;
-        max-width: none !important;
-      }
+/* ===== Tablettes paysage / écrans moins hauts ===== */
+@media (min-width: 701px) and (max-width: 1200px) and (max-height: 899px) {
+  .main-content {
+    width: min(640px, calc(100vw - 24px)) !important;
+    max-width: min(640px, calc(100vw - 24px)) !important;
+  }
 
-      #holdCanvas,
-      #nextCanvas {
-        width: 72px !important;
-        height: 72px !important;
-      }
-    }
+  .top-bar {
+    width: 100% !important;
+    max-width: none !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
 
-    /* ===== Tablettes paysage / écrans moins hauts ===== */
-    @media (min-width: 701px) and (max-width: 1200px) and (max-height: 899px) {
-      .main-content {
-        width: min(600px, calc(100vw - 24px)) !important;
-        max-width: min(600px, calc(100vw - 24px)) !important;
-      }
+  .top-canvas-row {
+    width: min(100%, 640px) !important;
+    max-width: 640px !important;
+    margin-top: -14px !important;
+    margin-bottom: clamp(9px, 1.2vh, 16px) !important;
+  }
+
+  .score-row {
+    width: 100% !important;
+    max-width: none !important;
+  }
+}
 
       .top-bar {
         width: 100% !important;

--- a/duel.html
+++ b/duel.html
@@ -63,6 +63,7 @@
       padding-bottom: calc(var(--safe-bottom) + 14px);
       transform-origin: top center;
       will-change: transform;
+      --vblocks-ui-scale: 1;
     }
 
     /* === TOP BAR (comme classic) === */
@@ -92,13 +93,18 @@
       display: flex; align-items: center; justify-content: center;
       border-radius: 50%; padding: 4px;
       cursor: pointer;
-      width: 42px; height: 42px;
+      width: clamp(32px, calc(42px * var(--vblocks-ui-scale)), 56px);
+      height: clamp(32px, calc(42px * var(--vblocks-ui-scale)), 56px);
       transition: background 0.15s;
     }
-    .btn-back img { width: 28px; height: 28px; filter: drop-shadow(0 1px 2px #0005);}
+    .btn-back img {
+      width: clamp(20px, calc(28px * var(--vblocks-ui-scale)), 38px);
+      height: clamp(20px, calc(28px * var(--vblocks-ui-scale)), 38px);
+      filter: drop-shadow(0 1px 2px #0005);
+    }
     .main-title {
       flex: 1;
-      font-size: 1.25em; font-weight: 900;
+      font-size: clamp(0.98rem, calc(1.25rem * var(--vblocks-ui-scale)), 1.55rem); font-weight: 900;
       color: var(--title-color, #39ff14);
       letter-spacing: 2px; line-height: 1.1;
       text-align: center;
@@ -111,7 +117,10 @@
       flex-direction: row;
       gap: 8px;
     }
-    .btn-icon img { width: 27px; height: 27px; }
+    .btn-icon img {
+      width: clamp(20px, calc(27px * var(--vblocks-ui-scale)), 38px);
+      height: clamp(20px, calc(27px * var(--vblocks-ui-scale)), 38px);
+    }
 
     /* === Wallet identique === */
     .wallet-block {
@@ -163,7 +172,10 @@
 }
     .side-canvas-block { display: flex; flex-direction: column; align-items: center; gap: 2px; }
     .side-canvas-block label {
-      font-size: 1em; font-weight: 700; margin-bottom: 2px; color: var(--panel-text, #39ff14);
+      font-size: clamp(0.82rem, calc(1rem * var(--vblocks-ui-scale)), 1.2rem);
+      font-weight: 700;
+      margin-bottom: 2px;
+      color: var(--panel-text, #39ff14);
       text-align: center;
     }
     #holdCanvas, #nextCanvas {
@@ -186,8 +198,8 @@
     }
 
     #gameCanvas {
-      width: 100%;
-      max-width: 330px;
+      width: min(100%, 330px);
+      max-width: none;
       aspect-ratio: 12/22;
       height: auto;
       max-height: none;
@@ -201,7 +213,9 @@
 
     /* === Scores identiques === */
     .score-row {
-      margin-top: 8px; font-size: 1.08em; font-weight: 700;
+      margin-top: clamp(7px, calc(8px * var(--vblocks-ui-scale)), 12px);
+      font-size: clamp(0.92rem, calc(1.08rem * var(--vblocks-ui-scale)), 1.28rem);
+      font-weight: 700;
       display: flex; flex-wrap: wrap; justify-content: center; gap: 1em 2em;
       color: var(--score-color, #39ff14);
       width: 97vw; max-width: 430px; letter-spacing: 0.6px; flex-shrink: 0;
@@ -218,7 +232,8 @@
       background: var(--btn-bg, #161649);
       color: var(--btn-color, #39ff14);
       font-weight: 700; border: none; border-radius: 1.1em;
-      padding: 0.68em 1.4em; font-size: 1.03em;
+      padding: clamp(0.58em, calc(0.68em * var(--vblocks-ui-scale)), 0.82em) clamp(1.15em, calc(1.4em * var(--vblocks-ui-scale)), 1.75em);
+      font-size: clamp(0.92rem, calc(1.03rem * var(--vblocks-ui-scale)), 1.2rem);
       cursor: pointer; box-shadow: 0 1.5px 7px #00fff738;
     }
     #controls button:active {
@@ -248,48 +263,58 @@
     }
     .duel-code { font-size: 1.5em; letter-spacing: 2px; margin: 8px 0 6px 0; color: #ffd800; font-family: monospace; }
     /* ===== Tablettes portrait et grands écrans tactiles ===== */
-    @media (min-width: 701px) and (max-width: 1200px) and (min-height: 900px) {
-      .main-content {
-        width: min(720px, calc(100vw - 32px)) !important;
-        max-width: min(720px, calc(100vw - 32px)) !important;
-      }
+@media (min-width: 701px) and (max-width: 1200px) and (min-height: 900px) {
+  .main-content {
+    width: min(760px, calc(100vw - 32px)) !important;
+    max-width: min(760px, calc(100vw - 32px)) !important;
+  }
 
-      .top-bar {
-        width: 100% !important;
-        max-width: none !important;
-        padding-left: 0 !important;
-        padding-right: 0 !important;
-      }
+  .top-bar {
+    width: 100% !important;
+    max-width: none !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
 
-      .top-canvas-row {
-        width: min(100%, 700px) !important;
-        max-width: 700px !important;
-        margin-top: -12px !important;
-      }
+  .top-canvas-row {
+    width: min(100%, 760px) !important;
+    max-width: 760px !important;
+    margin-top: -12px !important;
+    margin-bottom: clamp(12px, 1.4vh, 20px) !important;
+  }
 
-      #gameCanvas {
-        width: 100% !important;
-        max-width: 520px !important;
-      }
+  .score-row {
+    width: 100% !important;
+    max-width: none !important;
+  }
+}
 
-      .score-row {
-        width: 100% !important;
-        max-width: none !important;
-      }
+/* ===== Tablettes paysage / écrans moins hauts ===== */
+@media (min-width: 701px) and (max-width: 1200px) and (max-height: 899px) {
+  .main-content {
+    width: min(640px, calc(100vw - 24px)) !important;
+    max-width: min(640px, calc(100vw - 24px)) !important;
+  }
 
-      #holdCanvas,
-      #nextCanvas {
-        width: 72px !important;
-        height: 72px !important;
-      }
-    }
+  .top-bar {
+    width: 100% !important;
+    max-width: none !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
 
-    /* ===== Tablettes paysage / écrans moins hauts ===== */
-    @media (min-width: 701px) and (max-width: 1200px) and (max-height: 899px) {
-      .main-content {
-        width: min(600px, calc(100vw - 24px)) !important;
-        max-width: min(600px, calc(100vw - 24px)) !important;
-      }
+  .top-canvas-row {
+    width: min(100%, 640px) !important;
+    max-width: 640px !important;
+    margin-top: -14px !important;
+    margin-bottom: clamp(9px, 1.2vh, 16px) !important;
+  }
+
+  .score-row {
+    width: 100% !important;
+    max-width: none !important;
+  }
+}
 
       .top-bar {
         width: 100% !important;
@@ -346,8 +371,8 @@
 }
 
 .top-mini-action img {
-  width: clamp(21px, 7vw, 25px);
-  height: clamp(21px, 7vw, 25px);
+  width: clamp(20px, calc(25px * var(--vblocks-ui-scale)), 38px);
+  height: clamp(20px, calc(25px * var(--vblocks-ui-scale)), 38px);
   display: block;
   object-fit: contain;
 }

--- a/infini.html
+++ b/infini.html
@@ -60,6 +60,7 @@ body {
   padding-bottom: calc(var(--safe-bottom) + 14px);
   transform-origin: top center;
   will-change: transform;
+  --vblocks-ui-scale: 1;
 }
 .top-bar {
       width: 100%;
@@ -87,13 +88,18 @@ body {
       display: flex; align-items: center; justify-content: center;
       border-radius: 50%; padding: 4px;
       cursor: pointer;
-      width: 42px; height: 42px;
+      width: clamp(32px, calc(42px * var(--vblocks-ui-scale)), 56px);
+      height: clamp(32px, calc(42px * var(--vblocks-ui-scale)), 56px);
       transition: background 0.15s;
     }
-    .btn-back img { width: 28px; height: 28px; filter: drop-shadow(0 1px 2px #0005);}
+    .btn-back img {
+      width: clamp(20px, calc(28px * var(--vblocks-ui-scale)), 38px);
+      height: clamp(20px, calc(28px * var(--vblocks-ui-scale)), 38px);
+      filter: drop-shadow(0 1px 2px #0005);
+    }
     .main-title {
       flex: 1;
-      font-size: 1.25em; font-weight: 900;
+      font-size: clamp(0.98rem, calc(1.25rem * var(--vblocks-ui-scale)), 1.55rem); font-weight: 900;
       color: var(--title-color, #39ff14);
       letter-spacing: 2px; line-height: 1.1;
       text-align: center;
@@ -106,7 +112,10 @@ body {
       flex-direction: row;
       gap: 8px;
     }
-    .btn-icon img { width: 27px; height: 27px; }
+    .btn-icon img {
+      width: clamp(20px, calc(27px * var(--vblocks-ui-scale)), 38px);
+      height: clamp(20px, calc(27px * var(--vblocks-ui-scale)), 38px);
+    }
 
     .wallet-block {
       width: 100%;
@@ -163,7 +172,10 @@ body {
       display: flex; flex-direction: column; align-items: center; gap: 2px;
     }
     .side-canvas-block label {
-      font-size: 1em; font-weight: 700; margin-bottom: 2px; color: var(--panel-text, #39ff14);
+      font-size: clamp(0.82rem, calc(1rem * var(--vblocks-ui-scale)), 1.2rem);
+      font-weight: 700;
+      margin-bottom: 2px;
+      color: var(--panel-text, #39ff14);
       text-align: center;
     }
 #holdCanvas, #nextCanvas {
@@ -191,8 +203,8 @@ body {
     }
 
     #gameCanvas {
-      width: 100%;
-      max-width: 330px;
+      width: min(100%, 330px);
+      max-width: none;
       aspect-ratio: 12/22;
       height: auto;
       max-height: none;
@@ -204,7 +216,9 @@ body {
       touch-action: none;
     }
     .score-row {
-      margin-top: 8px; font-size: 1.08em; font-weight: 700;
+      margin-top: clamp(7px, calc(8px * var(--vblocks-ui-scale)), 12px);
+      font-size: clamp(0.92rem, calc(1.08rem * var(--vblocks-ui-scale)), 1.28rem);
+      font-weight: 700;
       display: flex; flex-wrap: wrap; justify-content: center; gap: 1em 2em;
       color: var(--score-color, #39ff14);
       width: 97vw; max-width: 430px; letter-spacing: 0.6px; flex-shrink: 0;
@@ -221,7 +235,8 @@ body {
       background: var(--btn-bg, #161649);
       color: var(--btn-color, #39ff14);
       font-weight: 700; border: none; border-radius: 1.1em;
-      padding: 0.68em 1.4em; font-size: 1.03em;
+      padding: clamp(0.58em, calc(0.68em * var(--vblocks-ui-scale)), 0.82em) clamp(1.15em, calc(1.4em * var(--vblocks-ui-scale)), 1.75em);
+      font-size: clamp(0.92rem, calc(1.03rem * var(--vblocks-ui-scale)), 1.2rem);
       cursor: pointer; box-shadow: 0 1.5px 7px #00fff738;
     }
     #controls button:active {
@@ -229,48 +244,58 @@ body {
       color: var(--btn-hover-color, #fff);
     }
     /* ===== Tablettes portrait et grands écrans tactiles ===== */
-    @media (min-width: 701px) and (max-width: 1200px) and (min-height: 900px) {
-      .main-content {
-        width: min(720px, calc(100vw - 32px)) !important;
-        max-width: min(720px, calc(100vw - 32px)) !important;
-      }
+@media (min-width: 701px) and (max-width: 1200px) and (min-height: 900px) {
+  .main-content {
+    width: min(760px, calc(100vw - 32px)) !important;
+    max-width: min(760px, calc(100vw - 32px)) !important;
+  }
 
-      .top-bar {
-        width: 100% !important;
-        max-width: none !important;
-        padding-left: 0 !important;
-        padding-right: 0 !important;
-      }
+  .top-bar {
+    width: 100% !important;
+    max-width: none !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
 
-      .top-canvas-row {
-        width: min(100%, 700px) !important;
-        max-width: 700px !important;
-        margin-top: -12px !important;
-      }
+  .top-canvas-row {
+    width: min(100%, 760px) !important;
+    max-width: 760px !important;
+    margin-top: -12px !important;
+    margin-bottom: clamp(12px, 1.4vh, 20px) !important;
+  }
 
-      #gameCanvas {
-        width: 100% !important;
-        max-width: 520px !important;
-      }
+  .score-row {
+    width: 100% !important;
+    max-width: none !important;
+  }
+}
 
-      .score-row {
-        width: 100% !important;
-        max-width: none !important;
-      }
+/* ===== Tablettes paysage / écrans moins hauts ===== */
+@media (min-width: 701px) and (max-width: 1200px) and (max-height: 899px) {
+  .main-content {
+    width: min(640px, calc(100vw - 24px)) !important;
+    max-width: min(640px, calc(100vw - 24px)) !important;
+  }
 
-      #holdCanvas,
-      #nextCanvas {
-        width: 72px !important;
-        height: 72px !important;
-      }
-    }
+  .top-bar {
+    width: 100% !important;
+    max-width: none !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
 
-    /* ===== Tablettes paysage / écrans moins hauts ===== */
-    @media (min-width: 701px) and (max-width: 1200px) and (max-height: 899px) {
-      .main-content {
-        width: min(600px, calc(100vw - 24px)) !important;
-        max-width: min(600px, calc(100vw - 24px)) !important;
-      }
+  .top-canvas-row {
+    width: min(100%, 640px) !important;
+    max-width: 640px !important;
+    margin-top: -14px !important;
+    margin-bottom: clamp(9px, 1.2vh, 16px) !important;
+  }
+
+  .score-row {
+    width: 100% !important;
+    max-width: none !important;
+  }
+}
 
       .top-bar {
         width: 100% !important;
@@ -327,8 +352,8 @@ body {
 }
 
 .top-mini-action img {
-  width: clamp(21px, 7vw, 25px);
-  height: clamp(21px, 7vw, 25px);
+  width: clamp(20px, calc(25px * var(--vblocks-ui-scale)), 38px);
+  height: clamp(20px, calc(25px * var(--vblocks-ui-scale)), 38px);
   display: block;
   object-fit: contain;
 }

--- a/js/game.js
+++ b/js/game.js
@@ -211,9 +211,40 @@ function fillRectThemeSafe(c, px, py, size) {
     const mainContent = document.querySelector('.main-content');
     let resizeRAF = null;
 
+    function clampNumber(value, min, max) {
+      return Math.max(min, Math.min(max, value));
+    }
+
     function fitCanvasToCSS() {
-      const cssW = Math.round(canvas.clientWidth || canvas.getBoundingClientRect().width);
-      if (!cssW) return;
+      const vv = window.visualViewport;
+      const viewportW = Math.round(vv?.width || window.innerWidth || 430);
+      const viewportH = Math.round(vv?.height || window.innerHeight || 800);
+
+      const isTabletLike = viewportW >= 700 && viewportH >= 560;
+
+      const maxBoardW = isTabletLike ? 570 : 340;
+      const minBoardW = viewportW <= 360 ? 282 : 304;
+
+      const horizontalLimit = viewportW - (isTabletLike ? 80 : 18);
+      const verticalReserve = isTabletLike
+        ? (viewportH >= 900 ? 295 : 245)
+        : 210;
+
+      const verticalLimit = (viewportH - verticalReserve) * (COLS / ROWS);
+
+      let cssW = Math.round(
+        clampNumber(
+          Math.min(horizontalLimit, verticalLimit, maxBoardW),
+          minBoardW,
+          maxBoardW
+        )
+      );
+
+      if (viewportW <= 360) {
+        cssW = Math.min(cssW, viewportW - 18);
+      }
+
+      canvas.style.width = cssW + 'px';
 
       BLOCK_SIZE = cssW / COLS;
 
@@ -226,6 +257,11 @@ function fillRectThemeSafe(c, px, py, size) {
       canvas.height = Math.round(usedH * DPR);
 
       ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+
+      if (mainContent) {
+        const uiScale = clampNumber(cssW / 330, 0.88, 1.5);
+        mainContent.style.setProperty('--vblocks-ui-scale', String(uiScale));
+      }
     }
 
     function fitWholeGameUI() {
@@ -267,10 +303,19 @@ function fillRectThemeSafe(c, px, py, size) {
 
     function sizeMiniCanvas(cnv, c2d, target = 48) {
       if (!cnv || !c2d) return;
-      cnv.style.width  = target + 'px';
-      cnv.style.height = target + 'px';
-      cnv.width  = Math.round(target * DPR);
-      cnv.height = Math.round(target * DPR);
+
+      let uiScale = 1;
+      try {
+        uiScale = parseFloat(mainContent?.style.getPropertyValue('--vblocks-ui-scale')) || 1;
+      } catch (_) {}
+
+      const finalTarget = Math.round(clampNumber(target * uiScale, 44, 82));
+
+      cnv.style.width = finalTarget + 'px';
+      cnv.style.height = finalTarget + 'px';
+      cnv.width = Math.round(finalTarget * DPR);
+      cnv.height = Math.round(finalTarget * DPR);
+
       c2d.setTransform(DPR, 0, 0, DPR, 0, 0);
       c2d.imageSmoothingEnabled = false;
     }

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -163,9 +163,40 @@ function fillRectThemeSafe(c, px, py, size) {
     const mainContent = document.querySelector('.main-content');
     let resizeRAF = null;
 
+    function clampNumber(value, min, max) {
+      return Math.max(min, Math.min(max, value));
+    }
+
     function fitCanvasToCSS() {
-      const cssW = Math.round(canvas.clientWidth || canvas.getBoundingClientRect().width);
-      if (!cssW) return;
+      const vv = window.visualViewport;
+      const viewportW = Math.round(vv?.width || window.innerWidth || 430);
+      const viewportH = Math.round(vv?.height || window.innerHeight || 800);
+
+      const isTabletLike = viewportW >= 700 && viewportH >= 560;
+
+      const maxBoardW = isTabletLike ? 570 : 340;
+      const minBoardW = viewportW <= 360 ? 282 : 304;
+
+      const horizontalLimit = viewportW - (isTabletLike ? 80 : 18);
+      const verticalReserve = isTabletLike
+        ? (viewportH >= 900 ? 295 : 245)
+        : 210;
+
+      const verticalLimit = (viewportH - verticalReserve) * (COLS / ROWS);
+
+      let cssW = Math.round(
+        clampNumber(
+          Math.min(horizontalLimit, verticalLimit, maxBoardW),
+          minBoardW,
+          maxBoardW
+        )
+      );
+
+      if (viewportW <= 360) {
+        cssW = Math.min(cssW, viewportW - 18);
+      }
+
+      canvas.style.width = cssW + 'px';
 
       BLOCK_SIZE = cssW / COLS;
 
@@ -173,10 +204,16 @@ function fillRectThemeSafe(c, px, py, size) {
       const usedH = BLOCK_SIZE * ROWS;
 
       canvas.style.height = usedH + 'px';
+
       canvas.width = Math.round(usedW * DPR);
       canvas.height = Math.round(usedH * DPR);
 
       ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+
+      if (mainContent) {
+        const uiScale = clampNumber(cssW / 330, 0.88, 1.5);
+        mainContent.style.setProperty('--vblocks-ui-scale', String(uiScale));
+      }
     }
 
     function fitWholeGameUI() {
@@ -214,10 +251,19 @@ function fillRectThemeSafe(c, px, py, size) {
     }
     function sizeMiniCanvas(cnv, c2d, target = 48) {
       if (!cnv || !c2d) return;
-      cnv.style.width = target + 'px';
-      cnv.style.height = target + 'px';
-      cnv.width = Math.round(target * DPR);
-      cnv.height = Math.round(target * DPR);
+
+      let uiScale = 1;
+      try {
+        uiScale = parseFloat(mainContent?.style.getPropertyValue('--vblocks-ui-scale')) || 1;
+      } catch (_) {}
+
+      const finalTarget = Math.round(clampNumber(target * uiScale, 44, 82));
+
+      cnv.style.width = finalTarget + 'px';
+      cnv.style.height = finalTarget + 'px';
+      cnv.width = Math.round(finalTarget * DPR);
+      cnv.height = Math.round(finalTarget * DPR);
+
       c2d.setTransform(DPR, 0, 0, DPR, 0, 0);
       c2d.imageSmoothingEnabled = false;
     }


### PR DESCRIPTION
### Motivation
- Harmoniser le rendu du canvas et des mini-canvases avec la taille réelle du viewport en tenant compte de `window.visualViewport` et des tailles tablette/phone.
- Permettre un facteur d'échelle UI contrôlable via la variable CSS `--vblocks-ui-scale` pour agrandir/réduire titres, boutons et icônes selon l'espace disponible.
- Adapter les media queries tablettes pour offrir des largeurs maximales et espacements spécifiques aux formats portrait et paysage.

### Description
- Remplacé `fitCanvasToCSS()` dans `js/game.js` et `js/game_duel.js` par une version basée sur le viewport (ajout de `clampNumber()` et règles de limites tablette/mobile) qui met aussi à jour `--vblocks-ui-scale`.
- Mis à jour `sizeMiniCanvas()` dans les deux fichiers JS pour lire `--vblocks-ui-scale` et calculer un `finalTarget` clampé avant de redimensionner les mini-canvases.
- Ajouté `--vblocks-ui-scale: 1;` à `.main-content` dans `classic.html`, `infini.html` et `duel.html` et remplacé plusieurs règles CSS (`.main-title`, `.btn-back`, `.btn-back img`, `.btn-icon img`, `.top-mini-action img`, `.side-canvas-block label`, `#gameCanvas`, `.score-row`, `#controls button`) par des variantes utilisant `clamp()` et `var(--vblocks-ui-scale)`.
- Remplacé les deux media queries tablettes (portrait et paysage) dans `classic.html`, `infini.html` et `duel.html` par les blocs fournis qui ajustent ` .main-content`, `.top-bar`, `.top-canvas-row` et `.score-row`.

### Testing
- Aucune suite de tests automatisés n'a été exécutée pour ces ajustements UI/CSS/JS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15b5996c1c8321b38b90f7e9c74793)