### PR TITLE
Corrige le scaling des mini-canvas et met à jour les media queries tablette

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -295,10 +295,84 @@
         padding-right: 0 !important;
       }
 
+      .top-bar-row {
+        gap: 14px !important;
+      }
+
+      .btn-back {
+        width: 56px !important;
+        height: 56px !important;
+        padding: 5px !important;
+      }
+
+      .btn-back img {
+        width: 38px !important;
+        height: 38px !important;
+      }
+
+      .profile-row {
+        gap: 12px !important;
+      }
+
+      .btn-icon img {
+        width: 38px !important;
+        height: 38px !important;
+      }
+
+      .main-title {
+        font-size: 1.55em !important;
+        letter-spacing: 2.5px !important;
+      }
+
+      .wallet-block {
+        min-height: 46px !important;
+        gap: 24px !important;
+        margin-bottom: 10px !important;
+      }
+
+      .vcoins {
+        font-size: 1.35em !important;
+      }
+
+      .jetons {
+        font-size: 1.22em !important;
+      }
+
+      .vcoin-icon,
+      .jeton-icon {
+        width: 32px !important;
+        height: 32px !important;
+        margin-right: 8px !important;
+      }
+
       .top-canvas-row {
         width: min(100%, 700px) !important;
         max-width: 700px !important;
         margin-top: -12px !important;
+        margin-bottom: clamp(14px, 1.5vh, 22px) !important;
+      }
+
+      .side-canvas-block {
+        gap: 4px !important;
+      }
+
+      .side-canvas-block label {
+        font-size: 1.18em !important;
+        margin-bottom: 4px !important;
+      }
+
+      .center-top-controls {
+        gap: 14px !important;
+        padding-bottom: 10px !important;
+      }
+
+      .top-mini-action {
+        padding: 4px !important;
+      }
+
+      .top-mini-action img {
+        width: 36px !important;
+        height: 36px !important;
       }
 
       #gameCanvas {
@@ -309,12 +383,24 @@
       .score-row {
         width: 100% !important;
         max-width: none !important;
+        margin-top: 10px !important;
+        font-size: 1.24em !important;
+        gap: 1em 2.2em !important;
       }
 
       #holdCanvas,
       #nextCanvas {
         width: 72px !important;
         height: 72px !important;
+      }
+
+      #controls {
+        margin-top: 13px !important;
+      }
+
+      #controls button {
+        font-size: 1.18em !important;
+        padding: 0.72em 1.45em !important;
       }
     }
 
@@ -332,10 +418,84 @@
         padding-right: 0 !important;
       }
 
+      .top-bar-row {
+        gap: 10px !important;
+      }
+
+      .btn-back {
+        width: 46px !important;
+        height: 46px !important;
+        padding: 4px !important;
+      }
+
+      .btn-back img {
+        width: 31px !important;
+        height: 31px !important;
+      }
+
+      .profile-row {
+        gap: 10px !important;
+      }
+
+      .btn-icon img {
+        width: 31px !important;
+        height: 31px !important;
+      }
+
+      .main-title {
+        font-size: 1.28em !important;
+        letter-spacing: 2px !important;
+      }
+
+      .wallet-block {
+        min-height: 40px !important;
+        gap: 20px !important;
+        margin-bottom: 8px !important;
+      }
+
+      .vcoins {
+        font-size: 1.18em !important;
+      }
+
+      .jetons {
+        font-size: 1.08em !important;
+      }
+
+      .vcoin-icon,
+      .jeton-icon {
+        width: 27px !important;
+        height: 27px !important;
+        margin-right: 6px !important;
+      }
+
       .top-canvas-row {
         width: min(100%, 560px) !important;
         max-width: 560px !important;
         margin-top: -14px !important;
+        margin-bottom: clamp(10px, 1.2vh, 16px) !important;
+      }
+
+      .side-canvas-block {
+        gap: 3px !important;
+      }
+
+      .side-canvas-block label {
+        font-size: 1.05em !important;
+        margin-bottom: 3px !important;
+      }
+
+      .center-top-controls {
+        gap: 10px !important;
+        padding-bottom: 8px !important;
+      }
+
+      .top-mini-action {
+        padding: 3px !important;
+      }
+
+      .top-mini-action img {
+        width: 30px !important;
+        height: 30px !important;
       }
 
       #gameCanvas {
@@ -346,12 +506,23 @@
       .score-row {
         width: 100% !important;
         max-width: none !important;
+        margin-top: 8px !important;
+        font-size: 1.08em !important;
       }
 
       #holdCanvas,
       #nextCanvas {
         width: 60px !important;
         height: 60px !important;
+      }
+
+      #controls {
+        margin-top: 11px !important;
+      }
+
+      #controls button {
+        font-size: 1.06em !important;
+        padding: 0.68em 1.4em !important;
       }
     }
 </style>

--- a/duel.html
+++ b/duel.html
@@ -261,10 +261,84 @@
         padding-right: 0 !important;
       }
 
+      .top-bar-row {
+        gap: 14px !important;
+      }
+
+      .btn-back {
+        width: 56px !important;
+        height: 56px !important;
+        padding: 5px !important;
+      }
+
+      .btn-back img {
+        width: 38px !important;
+        height: 38px !important;
+      }
+
+      .profile-row {
+        gap: 12px !important;
+      }
+
+      .btn-icon img {
+        width: 38px !important;
+        height: 38px !important;
+      }
+
+      .main-title {
+        font-size: 1.55em !important;
+        letter-spacing: 2.5px !important;
+      }
+
+      .wallet-block {
+        min-height: 46px !important;
+        gap: 24px !important;
+        margin-bottom: 10px !important;
+      }
+
+      .vcoins {
+        font-size: 1.35em !important;
+      }
+
+      .jetons {
+        font-size: 1.22em !important;
+      }
+
+      .vcoin-icon,
+      .jeton-icon {
+        width: 32px !important;
+        height: 32px !important;
+        margin-right: 8px !important;
+      }
+
       .top-canvas-row {
         width: min(100%, 700px) !important;
         max-width: 700px !important;
         margin-top: -12px !important;
+        margin-bottom: clamp(14px, 1.5vh, 22px) !important;
+      }
+
+      .side-canvas-block {
+        gap: 4px !important;
+      }
+
+      .side-canvas-block label {
+        font-size: 1.18em !important;
+        margin-bottom: 4px !important;
+      }
+
+      .center-top-controls {
+        gap: 14px !important;
+        padding-bottom: 10px !important;
+      }
+
+      .top-mini-action {
+        padding: 4px !important;
+      }
+
+      .top-mini-action img {
+        width: 36px !important;
+        height: 36px !important;
       }
 
       #gameCanvas {
@@ -275,12 +349,24 @@
       .score-row {
         width: 100% !important;
         max-width: none !important;
+        margin-top: 10px !important;
+        font-size: 1.24em !important;
+        gap: 1em 2.2em !important;
       }
 
       #holdCanvas,
       #nextCanvas {
         width: 72px !important;
         height: 72px !important;
+      }
+
+      #controls {
+        margin-top: 13px !important;
+      }
+
+      #controls button {
+        font-size: 1.18em !important;
+        padding: 0.72em 1.45em !important;
       }
     }
 
@@ -298,10 +384,84 @@
         padding-right: 0 !important;
       }
 
+      .top-bar-row {
+        gap: 10px !important;
+      }
+
+      .btn-back {
+        width: 46px !important;
+        height: 46px !important;
+        padding: 4px !important;
+      }
+
+      .btn-back img {
+        width: 31px !important;
+        height: 31px !important;
+      }
+
+      .profile-row {
+        gap: 10px !important;
+      }
+
+      .btn-icon img {
+        width: 31px !important;
+        height: 31px !important;
+      }
+
+      .main-title {
+        font-size: 1.28em !important;
+        letter-spacing: 2px !important;
+      }
+
+      .wallet-block {
+        min-height: 40px !important;
+        gap: 20px !important;
+        margin-bottom: 8px !important;
+      }
+
+      .vcoins {
+        font-size: 1.18em !important;
+      }
+
+      .jetons {
+        font-size: 1.08em !important;
+      }
+
+      .vcoin-icon,
+      .jeton-icon {
+        width: 27px !important;
+        height: 27px !important;
+        margin-right: 6px !important;
+      }
+
       .top-canvas-row {
         width: min(100%, 560px) !important;
         max-width: 560px !important;
         margin-top: -14px !important;
+        margin-bottom: clamp(10px, 1.2vh, 16px) !important;
+      }
+
+      .side-canvas-block {
+        gap: 3px !important;
+      }
+
+      .side-canvas-block label {
+        font-size: 1.05em !important;
+        margin-bottom: 3px !important;
+      }
+
+      .center-top-controls {
+        gap: 10px !important;
+        padding-bottom: 8px !important;
+      }
+
+      .top-mini-action {
+        padding: 3px !important;
+      }
+
+      .top-mini-action img {
+        width: 30px !important;
+        height: 30px !important;
       }
 
       #gameCanvas {
@@ -312,12 +472,23 @@
       .score-row {
         width: 100% !important;
         max-width: none !important;
+        margin-top: 8px !important;
+        font-size: 1.08em !important;
       }
 
       #holdCanvas,
       #nextCanvas {
         width: 60px !important;
         height: 60px !important;
+      }
+
+      #controls {
+        margin-top: 11px !important;
+      }
+
+      #controls button {
+        font-size: 1.06em !important;
+        padding: 0.68em 1.4em !important;
       }
     }
 

--- a/infini.html
+++ b/infini.html
@@ -242,10 +242,84 @@ body {
         padding-right: 0 !important;
       }
 
+      .top-bar-row {
+        gap: 14px !important;
+      }
+
+      .btn-back {
+        width: 56px !important;
+        height: 56px !important;
+        padding: 5px !important;
+      }
+
+      .btn-back img {
+        width: 38px !important;
+        height: 38px !important;
+      }
+
+      .profile-row {
+        gap: 12px !important;
+      }
+
+      .btn-icon img {
+        width: 38px !important;
+        height: 38px !important;
+      }
+
+      .main-title {
+        font-size: 1.55em !important;
+        letter-spacing: 2.5px !important;
+      }
+
+      .wallet-block {
+        min-height: 46px !important;
+        gap: 24px !important;
+        margin-bottom: 10px !important;
+      }
+
+      .vcoins {
+        font-size: 1.35em !important;
+      }
+
+      .jetons {
+        font-size: 1.22em !important;
+      }
+
+      .vcoin-icon,
+      .jeton-icon {
+        width: 32px !important;
+        height: 32px !important;
+        margin-right: 8px !important;
+      }
+
       .top-canvas-row {
         width: min(100%, 700px) !important;
         max-width: 700px !important;
         margin-top: -12px !important;
+        margin-bottom: clamp(14px, 1.5vh, 22px) !important;
+      }
+
+      .side-canvas-block {
+        gap: 4px !important;
+      }
+
+      .side-canvas-block label {
+        font-size: 1.18em !important;
+        margin-bottom: 4px !important;
+      }
+
+      .center-top-controls {
+        gap: 14px !important;
+        padding-bottom: 10px !important;
+      }
+
+      .top-mini-action {
+        padding: 4px !important;
+      }
+
+      .top-mini-action img {
+        width: 36px !important;
+        height: 36px !important;
       }
 
       #gameCanvas {
@@ -256,12 +330,24 @@ body {
       .score-row {
         width: 100% !important;
         max-width: none !important;
+        margin-top: 10px !important;
+        font-size: 1.24em !important;
+        gap: 1em 2.2em !important;
       }
 
       #holdCanvas,
       #nextCanvas {
         width: 72px !important;
         height: 72px !important;
+      }
+
+      #controls {
+        margin-top: 13px !important;
+      }
+
+      #controls button {
+        font-size: 1.18em !important;
+        padding: 0.72em 1.45em !important;
       }
     }
 
@@ -279,10 +365,84 @@ body {
         padding-right: 0 !important;
       }
 
+      .top-bar-row {
+        gap: 10px !important;
+      }
+
+      .btn-back {
+        width: 46px !important;
+        height: 46px !important;
+        padding: 4px !important;
+      }
+
+      .btn-back img {
+        width: 31px !important;
+        height: 31px !important;
+      }
+
+      .profile-row {
+        gap: 10px !important;
+      }
+
+      .btn-icon img {
+        width: 31px !important;
+        height: 31px !important;
+      }
+
+      .main-title {
+        font-size: 1.28em !important;
+        letter-spacing: 2px !important;
+      }
+
+      .wallet-block {
+        min-height: 40px !important;
+        gap: 20px !important;
+        margin-bottom: 8px !important;
+      }
+
+      .vcoins {
+        font-size: 1.18em !important;
+      }
+
+      .jetons {
+        font-size: 1.08em !important;
+      }
+
+      .vcoin-icon,
+      .jeton-icon {
+        width: 27px !important;
+        height: 27px !important;
+        margin-right: 6px !important;
+      }
+
       .top-canvas-row {
         width: min(100%, 560px) !important;
         max-width: 560px !important;
         margin-top: -14px !important;
+        margin-bottom: clamp(10px, 1.2vh, 16px) !important;
+      }
+
+      .side-canvas-block {
+        gap: 3px !important;
+      }
+
+      .side-canvas-block label {
+        font-size: 1.05em !important;
+        margin-bottom: 3px !important;
+      }
+
+      .center-top-controls {
+        gap: 10px !important;
+        padding-bottom: 8px !important;
+      }
+
+      .top-mini-action {
+        padding: 3px !important;
+      }
+
+      .top-mini-action img {
+        width: 30px !important;
+        height: 30px !important;
       }
 
       #gameCanvas {
@@ -293,12 +453,23 @@ body {
       .score-row {
         width: 100% !important;
         max-width: none !important;
+        margin-top: 8px !important;
+        font-size: 1.08em !important;
       }
 
       #holdCanvas,
       #nextCanvas {
         width: 60px !important;
         height: 60px !important;
+      }
+
+      #controls {
+        margin-top: 11px !important;
+      }
+
+      #controls button {
+        font-size: 1.06em !important;
+        padding: 0.68em 1.4em !important;
       }
     }
 

--- a/js/game.js
+++ b/js/game.js
@@ -267,10 +267,17 @@ function fillRectThemeSafe(c, px, py, size) {
 
     function sizeMiniCanvas(cnv, c2d, target = 48) {
       if (!cnv || !c2d) return;
-      cnv.style.width  = target + 'px';
+
+      cnv.style.width = target + 'px';
       cnv.style.height = target + 'px';
-      cnv.width  = Math.round(target * DPR);
-      cnv.height = Math.round(target * DPR);
+
+      const rect = cnv.getBoundingClientRect();
+      const cssW = Math.max(1, Math.round(rect.width || target));
+      const cssH = Math.max(1, Math.round(rect.height || target));
+
+      cnv.width = Math.round(cssW * DPR);
+      cnv.height = Math.round(cssH * DPR);
+
       c2d.setTransform(DPR, 0, 0, DPR, 0, 0);
       c2d.imageSmoothingEnabled = false;
     }

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -214,10 +214,17 @@ function fillRectThemeSafe(c, px, py, size) {
     }
     function sizeMiniCanvas(cnv, c2d, target = 48) {
       if (!cnv || !c2d) return;
+
       cnv.style.width = target + 'px';
       cnv.style.height = target + 'px';
-      cnv.width = Math.round(target * DPR);
-      cnv.height = Math.round(target * DPR);
+
+      const rect = cnv.getBoundingClientRect();
+      const cssW = Math.max(1, Math.round(rect.width || target));
+      const cssH = Math.max(1, Math.round(rect.height || target));
+
+      cnv.width = Math.round(cssW * DPR);
+      cnv.height = Math.round(cssH * DPR);
+
       c2d.setTransform(DPR, 0, 0, DPR, 0, 0);
       c2d.imageSmoothingEnabled = false;
     }


### PR DESCRIPTION
### Motivation
- Les mini-canvases (Réserve / Suivante) étaient dimensionnés sur une valeur fixe multipliée par `DPR`, ce qui provoquait des morceaux non carrés ou flous quand le CSS agrandissait ces éléments sur tablette.
- Il faut que la taille interne en pixels des mini-canvases suive la taille CSS réellement rendue pour garder des pièces nettes et sans déformation.
- Les règles d'affichage pour tablettes devaient être uniformisées et remplacées dans les trois pages de jeu afin d'obtenir le comportement responsive demandé.

### Description
- Remplacement de `sizeMiniCanvas` dans `js/game.js` et `js/game_duel.js` pour utiliser `cnv.getBoundingClientRect()` et calculer `cssW` / `cssH` puis définir `cnv.width` / `cnv.height` en fonction de `DPR` avant d'appliquer `setTransform` et `imageSmoothingEnabled`.
- Mise à jour des deux blocs de media queries tablette (portrait + paysage) dans `classic.html`, `infini.html` et `duel.html` en remplaçant les blocs existants par les règles fournies (espacements, tailles d'icônes, tailles `#holdCanvas`/`#nextCanvas`, etc.).
- Aucun changement effectué sur la grande grille (board) ou sur la logique de rendu principale du jeu.

### Testing
- Vérification automatisée de la présence et du remplacement via `rg` pour localiser `function sizeMiniCanvas` et contrôle du contenu modifié avec `sed`/`nl`, et ces vérifications ont confirmé que les occurrences ont été mises à jour correctement.
- Exécution de scripts de remplacement automatisés (Python) pour appliquer les modifications et signaler le succès des remplacements; ces scripts se sont terminés sans erreur.
- Inspection automatisée des fichiers modifiés (`classic.html`, `infini.html`, `duel.html`, `js/game.js`, `js/game_duel.js`) a montré les nouveaux blocs et la nouvelle implémentation de `sizeMiniCanvas` en place; aucune erreur automatique détectée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17f2f0fce48321a63a02d41903d37c)