### PR TITLE
Switch top-canvas-row to grid and tighten control spacing/icons

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -154,24 +154,37 @@
       .jetons { font-size: .88em; }
     }
     .top-canvas-row {
-  width: 100%;
+  width: min(100%, 410px);
   max-width: 410px;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-bottom: clamp(10px, 1.8vh, 16px);
+  display: grid;
+  grid-template-columns: minmax(52px, 1fr) auto minmax(52px, 1fr);
+  align-items: end;
+  column-gap: clamp(6px, 2vw, 12px);
+  margin-bottom: clamp(8px, 1.4vh, 13px);
   margin-top: -30px;
   flex-shrink: 0;
+}
+
+.top-canvas-row .side-canvas-block:first-child {
+  justify-self: start;
+}
+
+.top-canvas-row .side-canvas-block:last-child {
+  justify-self: end;
+}
+
+.top-canvas-row .center-top-controls {
+  justify-self: center;
 }
 
     .center-top-controls {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: clamp(4px, 2.4vw, 10px);
+  gap: clamp(3px, 1.7vw, 8px);
   min-width: 0;
+  max-width: 100%;
   padding-bottom: 6px;
-  flex-shrink: 1;
 }
 
     .top-mini-action {
@@ -188,8 +201,8 @@
 }
 
     .top-mini-action img {
-  width: clamp(21px, 7vw, 25px);
-  height: clamp(21px, 7vw, 25px);
+  width: clamp(19px, 6vw, 24px);
+  height: clamp(19px, 6vw, 24px);
   display: block;
   object-fit: contain;
 }

--- a/duel.html
+++ b/duel.html
@@ -152,14 +152,27 @@
 
     /* === Panneaux HOLD/NEXT + pause identiques === */
     .top-canvas-row {
-  width: 100%;
+  width: min(100%, 410px);
   max-width: 410px;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-bottom: clamp(10px, 1.8vh, 16px);
+  display: grid;
+  grid-template-columns: minmax(52px, 1fr) auto minmax(52px, 1fr);
+  align-items: end;
+  column-gap: clamp(6px, 2vw, 12px);
+  margin-bottom: clamp(8px, 1.4vh, 13px);
   margin-top: -30px;
   flex-shrink: 0;
+}
+
+.top-canvas-row .side-canvas-block:first-child {
+  justify-self: start;
+}
+
+.top-canvas-row .side-canvas-block:last-child {
+  justify-self: end;
+}
+
+.top-canvas-row .center-top-controls {
+  justify-self: center;
 }
     .side-canvas-block { display: flex; flex-direction: column; align-items: center; gap: 2px; }
     .side-canvas-block label {
@@ -326,10 +339,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: clamp(4px, 2.4vw, 10px);
+  gap: clamp(3px, 1.7vw, 8px);
   min-width: 0;
+  max-width: 100%;
   padding-bottom: 6px;
-  flex-shrink: 1;
 }
 
 .top-mini-action {
@@ -346,8 +359,8 @@
 }
 
 .top-mini-action img {
-  width: clamp(21px, 7vw, 25px);
-  height: clamp(21px, 7vw, 25px);
+  width: clamp(19px, 6vw, 24px);
+  height: clamp(19px, 6vw, 24px);
   display: block;
   object-fit: contain;
 }

--- a/infini.html
+++ b/infini.html
@@ -150,14 +150,27 @@ body {
       .jetons { font-size: .88em; }
     }
 .top-canvas-row {
-  width: 100%;
+  width: min(100%, 410px);
   max-width: 410px;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-bottom: clamp(10px, 1.8vh, 16px);
+  display: grid;
+  grid-template-columns: minmax(52px, 1fr) auto minmax(52px, 1fr);
+  align-items: end;
+  column-gap: clamp(6px, 2vw, 12px);
+  margin-bottom: clamp(8px, 1.4vh, 13px);
   margin-top: -30px;
   flex-shrink: 0;
+}
+
+.top-canvas-row .side-canvas-block:first-child {
+  justify-self: start;
+}
+
+.top-canvas-row .side-canvas-block:last-child {
+  justify-self: end;
+}
+
+.top-canvas-row .center-top-controls {
+  justify-self: center;
 }
     .side-canvas-block {
       display: flex; flex-direction: column; align-items: center; gap: 2px;
@@ -307,10 +320,10 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: clamp(4px, 2.4vw, 10px);
+  gap: clamp(3px, 1.7vw, 8px);
   min-width: 0;
+  max-width: 100%;
   padding-bottom: 6px;
-  flex-shrink: 1;
 }
 
 .top-mini-action {
@@ -327,8 +340,8 @@ body {
 }
 
 .top-mini-action img {
-  width: clamp(21px, 7vw, 25px);
-  height: clamp(21px, 7vw, 25px);
+  width: clamp(19px, 6vw, 24px);
+  height: clamp(19px, 6vw, 24px);
   display: block;
   object-fit: contain;
 }


### PR DESCRIPTION
### Motivation
- Improve alignment of the HOLD / center controls / NEXT panels by switching the top row from a flexible layout to a predictable 3-column grid layout.  
- Reduce visual spacing in center controls and ensure the center column stays constrained on narrow viewports.  
- Slightly reduce top control icon sizes for better balance while keeping existing small-screen overrides intact.

### Description
- Replace `.top-canvas-row` flex rules with a 3-column CSS grid (`grid-template-columns: minmax(52px, 1fr) auto minmax(52px, 1fr)`) and add `column-gap` and adjusted `margin-bottom` in `classic.html`, `infini.html`, and `duel.html`.  
- Add child alignment rules: `.top-canvas-row .side-canvas-block:first-child` set to `justify-self: start`, `.top-canvas-row .side-canvas-block:last-child` set to `justify-self: end`, and `.top-canvas-row .center-top-controls` set to `justify-self: center` in all three files.  
- Update `.center-top-controls` to use a smaller `gap` and add `max-width: 100%` while removing the `flex-shrink` rule.  
- Reduce `.top-mini-action img` sizing to `clamp(19px, 6vw, 24px)` and preserve the existing `@media (max-width: 380px)` and `@media (max-width: 340px)` overrides.

### Testing
- Searched the three files for the affected selectors with `rg -n "\.top-canvas-row|\.center-top-controls|\.top-mini-action img|@media \(max-width: 380px\)|@media \(max-width: 340px\)" classic.html infini.html duel.html` and confirmed matches succeeded.  
- Reviewed the changes with `git diff -- classic.html infini.html duel.html` to verify only the intended CSS blocks were modified.  
- Committed the updates with `git add` and `git commit -m "Adjust top canvas row layout and control icon sizing"` and confirmed the commit completed successfully.  
- Performed file inspections (`sed`/`nl` slices) to ensure the new rules are present and the small-screen media queries remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17fc524a0c8321a4b6d539a6b0330e)