### PR TITLE
Adjust mobile top-row layout and mini canvas DPR sizing

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -195,6 +195,30 @@
 }
 
 @media (max-width: 380px) {
+  .top-canvas-row {
+    flex-wrap: wrap !important;
+    justify-content: space-between !important;
+    align-items: flex-start !important;
+    row-gap: 3px !important;
+    margin-top: -18px !important;
+    margin-bottom: 8px !important;
+  }
+
+  .top-canvas-row .side-canvas-block {
+    width: 58px !important;
+    flex: 0 0 58px !important;
+  }
+
+  .top-canvas-row .center-top-controls {
+    order: 3 !important;
+    width: 100% !important;
+    flex: 0 0 100% !important;
+    justify-content: center !important;
+    gap: 7px !important;
+    padding-bottom: 0 !important;
+    margin-top: 0 !important;
+  }
+
   .top-mini-action img {
     width: 22px !important;
     height: 22px !important;

--- a/duel.html
+++ b/duel.html
@@ -353,6 +353,30 @@
 }
 
 @media (max-width: 380px) {
+  .top-canvas-row {
+    flex-wrap: wrap !important;
+    justify-content: space-between !important;
+    align-items: flex-start !important;
+    row-gap: 3px !important;
+    margin-top: -18px !important;
+    margin-bottom: 8px !important;
+  }
+
+  .top-canvas-row .side-canvas-block {
+    width: 58px !important;
+    flex: 0 0 58px !important;
+  }
+
+  .top-canvas-row .center-top-controls {
+    order: 3 !important;
+    width: 100% !important;
+    flex: 0 0 100% !important;
+    justify-content: center !important;
+    gap: 7px !important;
+    padding-bottom: 0 !important;
+    margin-top: 0 !important;
+  }
+
   .top-mini-action img {
     width: 22px !important;
     height: 22px !important;

--- a/infini.html
+++ b/infini.html
@@ -334,6 +334,30 @@ body {
 }
 
 @media (max-width: 380px) {
+  .top-canvas-row {
+    flex-wrap: wrap !important;
+    justify-content: space-between !important;
+    align-items: flex-start !important;
+    row-gap: 3px !important;
+    margin-top: -18px !important;
+    margin-bottom: 8px !important;
+  }
+
+  .top-canvas-row .side-canvas-block {
+    width: 58px !important;
+    flex: 0 0 58px !important;
+  }
+
+  .top-canvas-row .center-top-controls {
+    order: 3 !important;
+    width: 100% !important;
+    flex: 0 0 100% !important;
+    justify-content: center !important;
+    gap: 7px !important;
+    padding-bottom: 0 !important;
+    margin-top: 0 !important;
+  }
+
   .top-mini-action img {
     width: 22px !important;
     height: 22px !important;

--- a/js/game.js
+++ b/js/game.js
@@ -267,10 +267,17 @@ function fillRectThemeSafe(c, px, py, size) {
 
     function sizeMiniCanvas(cnv, c2d, target = 48) {
       if (!cnv || !c2d) return;
-      cnv.style.width  = target + 'px';
+
+      cnv.style.width = target + 'px';
       cnv.style.height = target + 'px';
-      cnv.width  = Math.round(target * DPR);
-      cnv.height = Math.round(target * DPR);
+
+      const rect = cnv.getBoundingClientRect();
+      const cssW = Math.max(1, Math.round(rect.width || target));
+      const cssH = Math.max(1, Math.round(rect.height || target));
+
+      cnv.width = Math.round(cssW * DPR);
+      cnv.height = Math.round(cssH * DPR);
+
       c2d.setTransform(DPR, 0, 0, DPR, 0, 0);
       c2d.imageSmoothingEnabled = false;
     }

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -214,10 +214,17 @@ function fillRectThemeSafe(c, px, py, size) {
     }
     function sizeMiniCanvas(cnv, c2d, target = 48) {
       if (!cnv || !c2d) return;
+
       cnv.style.width = target + 'px';
       cnv.style.height = target + 'px';
-      cnv.width = Math.round(target * DPR);
-      cnv.height = Math.round(target * DPR);
+
+      const rect = cnv.getBoundingClientRect();
+      const cssW = Math.max(1, Math.round(rect.width || target));
+      const cssH = Math.max(1, Math.round(rect.height || target));
+
+      cnv.width = Math.round(cssW * DPR);
+      cnv.height = Math.round(cssH * DPR);
+
       c2d.setTransform(DPR, 0, 0, DPR, 0, 0);
       c2d.imageSmoothingEnabled = false;
     }


### PR DESCRIPTION
### Motivation
- Improve top-row alignment and control layout on very narrow screens by allowing the top canvas row to wrap and reflow.
- Ensure mini preview canvases render crisply by sizing their backing buffer from actual CSS-rendered dimensions before applying device pixel ratio in `sizeMiniCanvas`.

### Description
- Replaced the `@media (max-width: 380px)` block in `classic.html`, `infini.html`, and `duel.html` to add responsive rules for `.top-canvas-row`, `.side-canvas-block`, and `.center-top-controls` while keeping the `.top-mini-action img` size override.
- Updated `sizeMiniCanvas(cnv, c2d, target = 48)` in `js/game.js` and `js/game_duel.js` to use `cnv.getBoundingClientRect()` and compute `cssW`/`cssH` before setting `cnv.width`/`cnv.height` scaled by `DPR`.
- Kept existing layout behavior and icon sizing fallbacks for slightly different narrow breakpoints.

### Testing
- Searched and verified replacements with ripgrep via `rg` and inspected modified regions with `sed`, which located the updated CSS and functions successfully.
- Confirmed diffs with `git diff` and committed changes using `git commit`, producing commit `90ccd51` (commit succeeded).
- All automated verification commands executed in the transcript completed successfully (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1807510e288321a56bdcf7106be370)