### PR TITLE
Tighten top-control spacing and shrink icons for very small screens

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -195,16 +195,29 @@
 }
 
 @media (max-width: 380px) {
+  .center-top-controls {
+    gap: 1px !important;
+    padding-bottom: 6px !important;
+  }
+
+  .top-mini-action {
+    padding: 0 !important;
+  }
+
   .top-mini-action img {
-    width: 22px !important;
-    height: 22px !important;
+    width: 16px !important;
+    height: 16px !important;
   }
 }
 
 @media (max-width: 340px) {
+  .center-top-controls {
+    gap: 0 !important;
+  }
+
   .top-mini-action img {
-    width: 20px !important;
-    height: 20px !important;
+    width: 15px !important;
+    height: 15px !important;
   }
 }
     .side-canvas-block {

--- a/duel.html
+++ b/duel.html
@@ -353,16 +353,29 @@
 }
 
 @media (max-width: 380px) {
+  .center-top-controls {
+    gap: 1px !important;
+    padding-bottom: 6px !important;
+  }
+
+  .top-mini-action {
+    padding: 0 !important;
+  }
+
   .top-mini-action img {
-    width: 22px !important;
-    height: 22px !important;
+    width: 16px !important;
+    height: 16px !important;
   }
 }
 
 @media (max-width: 340px) {
+  .center-top-controls {
+    gap: 0 !important;
+  }
+
   .top-mini-action img {
-    width: 20px !important;
-    height: 20px !important;
+    width: 15px !important;
+    height: 15px !important;
   }
 }
 </style>

--- a/infini.html
+++ b/infini.html
@@ -334,16 +334,29 @@ body {
 }
 
 @media (max-width: 380px) {
+  .center-top-controls {
+    gap: 1px !important;
+    padding-bottom: 6px !important;
+  }
+
+  .top-mini-action {
+    padding: 0 !important;
+  }
+
   .top-mini-action img {
-    width: 22px !important;
-    height: 22px !important;
+    width: 16px !important;
+    height: 16px !important;
   }
 }
 
 @media (max-width: 340px) {
+  .center-top-controls {
+    gap: 0 !important;
+  }
+
   .top-mini-action img {
-    width: 20px !important;
-    height: 20px !important;
+    width: 15px !important;
+    height: 15px !important;
   }
 }
 </style>


### PR DESCRIPTION
### Motivation
- Improve layout on very narrow viewports by not only shrinking icons but also tightening spacing and removing extra padding so top controls fit better at `max-width: 380px` and `max-width: 340px`.

### Description
- Replaced the old icon-only reductions in `@media (max-width: 380px)` and `@media (max-width: 340px)` in `classic.html`, `infini.html`, and `duel.html` with new rules adjusting container spacing and icon sizes.
- Added `.center-top-controls { gap: 1px; padding-bottom: 6px; }` at `max-width: 380px` and `.center-top-controls { gap: 0; }` at `max-width: 340px` (both `!important`).
- Set `.top-mini-action { padding: 0 !important; }` at `max-width: 380px` and reduced `.top-mini-action img` sizes to `16px` at 380px and `15px` at 340px.
- Applied the change consistently across `classic.html`, `infini.html`, and `duel.html` using a scripted replacement.

### Testing
- Ran the scripted replacement (`python - <<'PY' ...`) which updated all three target files successfully and exited without errors.
- Verified the new CSS blocks exist in each file by searching for the `@media` rules and `center-top-controls`/`top-mini-action img` entries.
- No automated unit tests were modified and this is a CSS-only change, so no test failures were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a180e782a148321aa6cd09337c39281)