### PR TITLE
Refine reward and revive UI iconography across game flows and boutique

### DIFF
--- a/boutique.html
+++ b/boutique.html
@@ -102,7 +102,8 @@
 
     .achats-list .cartouche-reward {
       justify-content:center;
-      gap:2px;
+      gap:0;
+      min-height:74px;
     }
 
     .achats-list .cartouche-reward .theme-ico {
@@ -143,8 +144,24 @@
       display:flex;
       align-items:center;
       justify-content:center;
-      gap:8px;
-      margin-bottom:2px;
+      gap:7px;
+      margin-bottom:0;
+    }
+
+    .achats-list .cartouche-reward .reward-ad-icon img,
+    .achats-list .cartouche-reward .reward-prize-icon img {
+      width:26px;
+      height:26px;
+      object-fit:contain;
+      display:block;
+    }
+
+    .achats-list .cartouche-reward .reward-ad-icon img {
+      transform:translateY(1px);
+    }
+
+    .achats-list .cartouche-reward .reward-prize-icon img {
+      transform:translateY(2px);
     }
 
     .achats-list .cartouche-reward .reward-amount {
@@ -342,16 +359,23 @@ function renderCartouche(c, extraClass = ''){
           ? 'data-action="reward-vcoins"'
           : '';
 
+    const rewardPrizeIcon =
+      c.key === "boutique.cartouche.pub1jeton"
+        ? '<img src="assets/images/jeton.webp" alt="">'
+        : '<img src="assets/images/vcoin.webp" alt="">';
+
     return `
       <div class="special-cartouche ${c.color} ${classes}"
            ${c.productId ? `data-product-id="${c.productId}"` : ""}
            data-reward-key="${c.key}"
            ${rewardAction}>
         <div class="reward-top">
-          <span class="theme-ico">${c.icon}</span>
-          <span class="reward-amount">+ ${c.amount}</span>
+          <span class="reward-ad-icon">
+            <img src="assets/images/reward.webp" alt="" onerror="this.onerror=null;this.src='assets/images/ads.png';">
+          </span>
+          <span class="reward-prize-icon">${rewardPrizeIcon}</span>
+          <span class="reward-amount">+${c.amount}</span>
         </div>
-        <span class="theme-label" data-i18n="${c.key}">${t(c.key)}</span>
       </div>
     `;
   }

--- a/js/concours.js
+++ b/js/concours.js
@@ -866,7 +866,7 @@ function fillRectThemeSafe(c, px, py, size) {
               "
             >
               <span style="display:flex;align-items:center;justify-content:center;gap:10px;font-weight:800;width:100%;">
-                <img src="assets/images/vcoin.webp" alt="" style="width:24px;height:24px;object-fit:contain;">
+                <img src="assets/images/vcoin.webp" alt="" style="width:24px;height:24px;object-fit:contain;transform:translateY(2px);">
                 <span>+${rewardAmount}</span>
               </span>
             </button>
@@ -877,7 +877,12 @@ function fillRectThemeSafe(c, px, py, size) {
                 class="btn"
                 style="padding:.6em 1.1em;border-radius:.8em;background:#2a7;color:#fff;cursor:pointer;${canRevive ? '' : 'display:none;'}"
               >
-                ${tt('end.revive.token','Revivre (1 jeton)')}
+                <span style="display:flex;align-items:center;justify-content:center;gap:7px;font-weight:800;">
+  <span>${tt('end.revive.label','Revivre')}</span>
+  <span>(1</span>
+  <img src="assets/images/jeton.webp" alt="" style="width:22px;height:22px;object-fit:contain;">
+  <span>)</span>
+</span>
               </button>
 
               <button
@@ -885,7 +890,12 @@ function fillRectThemeSafe(c, px, py, size) {
                 class="btn"
                 style="padding:.6em 1.1em;border:none;border-radius:.8em;background:#a73;color:#fff;cursor:pointer;${canRevive ? '' : 'display:none;'}"
               >
-                ${tt('end.revive.ad','Revivre (pub)')}
+                <span style="display:flex;align-items:center;justify-content:center;gap:7px;font-weight:800;">
+  <span>${tt('end.revive.label','Revivre')}</span>
+  <span>(</span>
+  <img src="assets/images/reward.webp" alt="" onerror="this.onerror=null;this.src='assets/images/ads.png';" style="width:22px;height:22px;object-fit:contain;">
+  <span>)</span>
+</span>
               </button>
             </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -1120,7 +1120,7 @@ overlay.querySelector('#resume-yes').onclick = () => {
               "
             >
               <span style="display:flex;align-items:center;justify-content:center;gap:10px;font-weight:800;width:100%;">
-                <img src="assets/images/vcoin.webp" alt="" style="width:24px;height:24px;object-fit:contain;">
+                <img src="assets/images/vcoin.webp" alt="" style="width:24px;height:24px;object-fit:contain;transform:translateY(2px);">
                 <span>${rewardLabel}</span>
               </span>
             </button>
@@ -1131,7 +1131,12 @@ overlay.querySelector('#resume-yes').onclick = () => {
                 class="btn"
                 style="padding:.6em 1.1em;border-radius:.8em;background:#2a7;color:#fff;cursor:pointer;${canRevive ? '' : 'display:none;'}"
               >
-                ${tt('end.revive.token','Revivre (1 jeton)')}
+                <span style="display:flex;align-items:center;justify-content:center;gap:7px;font-weight:800;">
+  <span>${tt('end.revive.label','Revivre')}</span>
+  <span>(1</span>
+  <img src="assets/images/jeton.webp" alt="" style="width:22px;height:22px;object-fit:contain;">
+  <span>)</span>
+</span>
               </button>
 
               <button
@@ -1139,7 +1144,12 @@ overlay.querySelector('#resume-yes').onclick = () => {
                 class="btn"
                 style="padding:.6em 1.1em;border:none;border-radius:.8em;background:#a73;color:#fff;cursor:pointer;${canRevive ? '' : 'display:none;'}"
               >
-                ${tt('end.revive.ad','Revivre (pub)')}
+                <span style="display:flex;align-items:center;justify-content:center;gap:7px;font-weight:800;">
+  <span>${tt('end.revive.label','Revivre')}</span>
+  <span>(</span>
+  <img src="assets/images/reward.webp" alt="" onerror="this.onerror=null;this.src='assets/images/ads.png';" style="width:22px;height:22px;object-fit:contain;">
+  <span>)</span>
+</span>
               </button>
             </div>
 


### PR DESCRIPTION
### Motivation
- Improve visual alignment of VCoins icons in end-reward buttons for better pixel balance.
- Make revive actions more informative and visually consistent by showing inline icons for token and ad revives.
- Replace text-heavy boutique reward cartouches with a compact visual row (ad icon + prize icon + amount) for clearer presentation.

### Description
- Updated `js/game.js` to vertically offset the VCoins icon (`transform:translateY(2px)`) and replaced `end.revive.token` / `end.revive.ad` labels with inline icon-rich markup showing `Revivre (1 [jeton])` and `Revivre ([reward icon])` (with `ads.png` fallback).
- Applied the same VCoins offset and revive markup changes in `js/concours.js` to keep game and concours flows consistent.
- Modified `boutique.html` `renderCartouche` to render reward cartouches as a visual row: added a conditional `rewardPrizeIcon` (jeton vs vcoin), an ad icon with a fallback, and the `+amount` display while removing the previous textual label for these reward items.
- Adjusted boutique CSS for reward cartouches: `.cartouche-reward` now has `gap:0` and `min-height:74px`, `reward-top` spacing tweaked, and added icon sizing/vertical alignment rules for `.reward-ad-icon` and `.reward-prize-icon` images.

### Testing
- Searched and validated code locations with `rg -n "vcoin.webp|end.revive.token|end.revive.ad|renderCartouche\(c, extraClass|cartouche-reward|reward-top"` to confirm replacement targets were updated, and the search returned the updated occurrences.
- Applied the patches programmatically (patch tool reported success for `js/game.js`, `js/concours.js`, and `boutique.html`) and inspected resulting file regions using `nl -ba` and `sed -n` to verify the inserted blocks and CSS rules appear in the expected locations.
- Performed a repository diff to review the final changes and confirmed the modifications are limited to the three files above and are presentation-only; all automated checks executed here completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a180fc30f588321a86610a88e37688b)