### PR TITLE
Update reward and menu visuals

### DIFF
--- a/boutique.html
+++ b/boutique.html
@@ -104,6 +104,8 @@
       justify-content:center;
       gap:0;
       min-height:74px;
+      padding-top:.58em;
+      padding-bottom:.52em;
     }
 
     .achats-list .cartouche-reward .theme-ico {
@@ -144,23 +146,8 @@
       display:flex;
       align-items:center;
       justify-content:center;
-      gap:7px;
+      gap:6px;
       margin-bottom:0;
-    }
-
-    .achats-list .cartouche-reward .reward-ad-icon img,
-    .achats-list .cartouche-reward .reward-prize-icon img {
-      width:26px;
-      height:26px;
-      object-fit:contain;
-      display:block;
-    }
-
-    .achats-list .cartouche-reward .reward-ad-icon img {
-      transform:translateY(1px);
-    }
-
-    .achats-list .cartouche-reward .reward-prize-icon img {
       transform:translateY(2px);
     }
 
@@ -170,6 +157,24 @@
       font-size:1em;
       line-height:1;
       text-shadow:0 2px 5px rgba(0,0,0,.22);
+    }
+
+    .achats-list .cartouche-reward .reward-ad-icon img,
+    .achats-list .cartouche-reward .reward-prize-icon img {
+      display:block;
+      object-fit:contain;
+    }
+
+    .achats-list .cartouche-reward .reward-ad-icon img {
+      width:22px;
+      height:22px;
+      transform:translateY(1px);
+    }
+
+    .achats-list .cartouche-reward .reward-prize-icon img {
+      width:25px;
+      height:25px;
+      transform:translateY(4px);
     }
 
     .achats-list .cartouche-reward .theme-label {
@@ -361,8 +366,8 @@ function renderCartouche(c, extraClass = ''){
 
     const rewardPrizeIcon =
       c.key === "boutique.cartouche.pub1jeton"
-        ? '<img src="assets/images/jeton.webp" alt="">'
-        : '<img src="assets/images/vcoin.webp" alt="">';
+        ? 'assets/images/jeton.webp'
+        : 'assets/images/vcoin.webp';
 
     return `
       <div class="special-cartouche ${c.color} ${classes}"
@@ -373,7 +378,9 @@ function renderCartouche(c, extraClass = ''){
           <span class="reward-ad-icon">
             <img src="assets/images/reward.webp" alt="" onerror="this.onerror=null;this.src='assets/images/ads.png';">
           </span>
-          <span class="reward-prize-icon">${rewardPrizeIcon}</span>
+          <span class="reward-prize-icon">
+            <img src="${rewardPrizeIcon}" alt="">
+          </span>
           <span class="reward-amount">+${c.amount}</span>
         </div>
       </div>

--- a/js/concours.js
+++ b/js/concours.js
@@ -865,8 +865,9 @@ function fillRectThemeSafe(c, px, py, size) {
                 box-shadow:0 0 12px #39f7;
               "
             >
-              <span style="display:flex;align-items:center;justify-content:center;gap:10px;font-weight:800;width:100%;">
-                <img src="assets/images/vcoin.webp" alt="" style="width:24px;height:24px;object-fit:contain;transform:translateY(2px);">
+              <span style="display:flex;align-items:center;justify-content:center;gap:6px;font-weight:800;width:100%;">
+                <img src="assets/images/reward.webp" alt="" onerror="this.onerror=null;this.src='assets/images/ads.png';" style="width:21px;height:21px;object-fit:contain;transform:translateY(1px);">
+                <img src="assets/images/vcoin.webp" alt="" style="width:24px;height:24px;object-fit:contain;transform:translateY(3px);">
                 <span>+${rewardAmount}</span>
               </span>
             </button>
@@ -877,11 +878,10 @@ function fillRectThemeSafe(c, px, py, size) {
                 class="btn"
                 style="padding:.6em 1.1em;border-radius:.8em;background:#2a7;color:#fff;cursor:pointer;${canRevive ? '' : 'display:none;'}"
               >
-                <span style="display:flex;align-items:center;justify-content:center;gap:7px;font-weight:800;">
+                <span style="display:flex;align-items:center;justify-content:center;gap:6px;font-weight:800;">
   <span>${tt('end.revive.label','Revivre')}</span>
-  <span>(1</span>
-  <img src="assets/images/jeton.webp" alt="" style="width:22px;height:22px;object-fit:contain;">
-  <span>)</span>
+  <span>1</span>
+  <img src="assets/images/jeton.webp" alt="" style="width:22px;height:22px;object-fit:contain;transform:translateY(4px);">
 </span>
               </button>
 
@@ -890,11 +890,9 @@ function fillRectThemeSafe(c, px, py, size) {
                 class="btn"
                 style="padding:.6em 1.1em;border:none;border-radius:.8em;background:#a73;color:#fff;cursor:pointer;${canRevive ? '' : 'display:none;'}"
               >
-                <span style="display:flex;align-items:center;justify-content:center;gap:7px;font-weight:800;">
+                <span style="display:flex;align-items:center;justify-content:center;gap:6px;font-weight:800;">
   <span>${tt('end.revive.label','Revivre')}</span>
-  <span>(</span>
-  <img src="assets/images/reward.webp" alt="" onerror="this.onerror=null;this.src='assets/images/ads.png';" style="width:22px;height:22px;object-fit:contain;">
-  <span>)</span>
+  <img src="assets/images/reward.webp" alt="" onerror="this.onerror=null;this.src='assets/images/ads.png';" style="width:20px;height:20px;object-fit:contain;transform:translateY(1px);">
 </span>
               </button>
             </div>
@@ -1064,11 +1062,17 @@ function fillRectThemeSafe(c, px, py, size) {
                 <span>1</span>
               </span>
               <span style="font-weight:900;font-size:1.1em;">=</span>
-              <span style="font-weight:700;">${tt('end.revive.ad','Revivre (pub)')}</span>
+              <span style="display:flex;align-items:center;justify-content:center;gap:6px;font-weight:800;">
+  <span>${tt('end.revive.label','Revivre')}</span>
+  <img src="assets/images/reward.webp" alt="" onerror="this.onerror=null;this.src='assets/images/ads.png';" style="width:20px;height:20px;object-fit:contain;transform:translateY(1px);">
+</span>
             </div>
             <div style="opacity:.92;line-height:1.42;margin-bottom:14px;">${tt('end.no_tokens.body','Regarde une pub pour obtenir 1 reprise ou va à la boutique.')}</div>
             <div style="display:flex;gap:10px;justify-content:center;flex-wrap:wrap;">
-              <button id="no-jeton-watch-ad" class="btn-primary" style="padding:.7em 1em;border:none;border-radius:.85em;background:#a73;color:#fff;cursor:pointer;">${tt('end.revive.ad','Revivre (pub)')}</button>
+              <button id="no-jeton-watch-ad" class="btn-primary" style="padding:.7em 1em;border:none;border-radius:.85em;background:#a73;color:#fff;cursor:pointer;"><span style="display:flex;align-items:center;justify-content:center;gap:6px;font-weight:800;">
+  <span>${tt('end.revive.label','Revivre')}</span>
+  <img src="assets/images/reward.webp" alt="" onerror="this.onerror=null;this.src='assets/images/ads.png';" style="width:20px;height:20px;object-fit:contain;transform:translateY(1px);">
+</span></button>
               <button id="no-jeton-shop" class="btn" style="padding:.7em 1em;border:none;border-radius:.85em;background:#39f;color:#fff;cursor:pointer;">${tt('menu.boutique','Boutique')}</button>
             </div>
             <button id="no-jeton-close" style="margin-top:12px;background:transparent;border:none;color:#cfd8ff;cursor:pointer;opacity:.85;">${tt('common.later','Plus tard')}</button>

--- a/js/game.js
+++ b/js/game.js
@@ -1119,8 +1119,9 @@ overlay.querySelector('#resume-yes').onclick = () => {
                 box-shadow:0 0 12px #39f7;
               "
             >
-              <span style="display:flex;align-items:center;justify-content:center;gap:10px;font-weight:800;width:100%;">
-                <img src="assets/images/vcoin.webp" alt="" style="width:24px;height:24px;object-fit:contain;transform:translateY(2px);">
+              <span style="display:flex;align-items:center;justify-content:center;gap:6px;font-weight:800;width:100%;">
+                <img src="assets/images/reward.webp" alt="" onerror="this.onerror=null;this.src='assets/images/ads.png';" style="width:21px;height:21px;object-fit:contain;transform:translateY(1px);">
+                <img src="assets/images/vcoin.webp" alt="" style="width:24px;height:24px;object-fit:contain;transform:translateY(3px);">
                 <span>${rewardLabel}</span>
               </span>
             </button>
@@ -1131,11 +1132,10 @@ overlay.querySelector('#resume-yes').onclick = () => {
                 class="btn"
                 style="padding:.6em 1.1em;border-radius:.8em;background:#2a7;color:#fff;cursor:pointer;${canRevive ? '' : 'display:none;'}"
               >
-                <span style="display:flex;align-items:center;justify-content:center;gap:7px;font-weight:800;">
+                <span style="display:flex;align-items:center;justify-content:center;gap:6px;font-weight:800;">
   <span>${tt('end.revive.label','Revivre')}</span>
-  <span>(1</span>
-  <img src="assets/images/jeton.webp" alt="" style="width:22px;height:22px;object-fit:contain;">
-  <span>)</span>
+  <span>1</span>
+  <img src="assets/images/jeton.webp" alt="" style="width:22px;height:22px;object-fit:contain;transform:translateY(4px);">
 </span>
               </button>
 
@@ -1144,11 +1144,9 @@ overlay.querySelector('#resume-yes').onclick = () => {
                 class="btn"
                 style="padding:.6em 1.1em;border:none;border-radius:.8em;background:#a73;color:#fff;cursor:pointer;${canRevive ? '' : 'display:none;'}"
               >
-                <span style="display:flex;align-items:center;justify-content:center;gap:7px;font-weight:800;">
+                <span style="display:flex;align-items:center;justify-content:center;gap:6px;font-weight:800;">
   <span>${tt('end.revive.label','Revivre')}</span>
-  <span>(</span>
-  <img src="assets/images/reward.webp" alt="" onerror="this.onerror=null;this.src='assets/images/ads.png';" style="width:22px;height:22px;object-fit:contain;">
-  <span>)</span>
+  <img src="assets/images/reward.webp" alt="" onerror="this.onerror=null;this.src='assets/images/ads.png';" style="width:20px;height:20px;object-fit:contain;transform:translateY(1px);">
 </span>
               </button>
             </div>

--- a/style/main.css
+++ b/style/main.css
@@ -82,7 +82,7 @@ html, body {
   width: 230px;
   max-width: 74vw;
   margin-bottom: 13vh;
-  margin-top: 1vh;
+  margin-top: 2.6vh;
   filter: drop-shadow(0 8px 36px #28205c66);
   animation: pop-in .9s cubic-bezier(.21,1.1,.45,1.12);
   user-select: none;
@@ -99,7 +99,7 @@ html, body {
   gap: 2.6rem;
   width: 94vw;
   max-width: 430px;
-  margin-top: 7vh;
+  margin-top: 8.6vh;
 }
 .menu-btn {
   width: 100%;
@@ -209,8 +209,8 @@ html, body {
   to   { opacity: 1; transform: translateX(-50%) translateY(20px) scale(1);}
 }
 @media (max-width: 540px) {
-  .vblocks-logo { width: 49vw; margin-bottom: 7vh;}
-  .menu-list { gap: 1.6rem; max-width: 99vw; margin-top: 3vh;}
+  .vblocks-logo { width: 49vw; margin-top: 1.8vh; margin-bottom: 7vh; }
+  .menu-list { gap: 1.6rem; max-width: 99vw; margin-top: 4.2vh; }
   .menu-btn { font-size: 1.04rem; min-height: 59px; padding: 0 1.1rem;}
   .info-btn { width: 33px; height: 33px; font-size: 1.07rem;}
   .btn-label { font-size: 1.02em;}
@@ -642,14 +642,14 @@ body[data-universe="new_world_explorer"].vr-body-game #view-game .vr-choice-labe
   .vblocks-logo {
     width: min(320px, 42vw);
     max-width: 320px;
-    margin-top: 0.5vh;
+    margin-top: 1.6vh;
     margin-bottom: 7vh;
   }
 
   .menu-list {
     width: min(620px, 100%);
     max-width: 620px;
-    margin-top: 3vh;
+    margin-top: 4.2vh;
     gap: 2rem;
   }
 


### PR DESCRIPTION
### Motivation
- Standardize reward/revive UI to use compact icon layouts (reward icon + vcoin/jeton) for a cleaner look in both normal and concours modes.
- Replace verbose textual labels for ad-based revives with icon-based presentation to improve visual consistency.
- Simplify boutique cartouches to show only the reward icon, prize icon, and amount, removing extra text.
- Nudge the index layout by lowering the VBlocks logo and menu blocks to improve spacing on desktop, tablet, and mobile.

### Description
- Updated end-of-game reward button and revive buttons in `js/game.js` to render a `reward.webp` icon, a `vcoin.webp` icon, and adjusted spacing/`transform` offsets, and applied the same changes in `js/concours.js` for concours mode.
- Reworked revive presentations (token and ad) in `js/game.js` and `js/concours.js` to use compact icon + label markup and added `onerror` fallback to `assets/images/ads.png` for the reward icon.
- Modified `boutique.html` CSS for `.achats-list .cartouche-reward` and `.reward-top` (spacing, min-height, padding, translateY) and added styles for `.reward-ad-icon img` / `.reward-prize-icon img` to control sizing and vertical alignment.
- Rewrote the boutique reward rendering logic in `boutique.html` to choose the prize icon path (`jeton.webp` or `vcoin.webp`) and output a dedicated `<img>` tag for the prize icon instead of inline HTML fragments.
- Adjusted layout spacing in `style/main.css` by changing `margin-top` values for `.vblocks-logo` and `.menu-list` across base, mobile (`@media (max-width: 540px)`), and tablet/large (`@media (min-width: 768px)`) rules.

### Testing
- Ran `node --check js/game.js` and it passed without syntax errors.
- Ran `node --check js/concours.js` and it passed without syntax errors.
- Verified required image assets exist with `test -f assets/images/reward.webp && test -f assets/images/vcoin.webp && test -f assets/images/jeton.webp && test -f assets/images/ads.png`, which succeeded.
- Ran `git diff --check` to ensure no obvious diff issues and it reported no problems.
- Visual/browser smoke test was skipped because no headless browser or `playwright` executable was available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a198007befc8321aafc14938e972724)