### PR TITLE
Adjust Vblocks logo spacing across breakpoints

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -82,7 +82,7 @@ html, body {
   width: 230px;
   max-width: 74vw;
   margin-bottom: 13vh;
-  margin-top: 2.6vh;
+  margin-top: 3vh;
   filter: drop-shadow(0 8px 36px #28205c66);
   animation: pop-in .9s cubic-bezier(.21,1.1,.45,1.12);
   user-select: none;
@@ -209,7 +209,7 @@ html, body {
   to   { opacity: 1; transform: translateX(-50%) translateY(20px) scale(1);}
 }
 @media (max-width: 540px) {
-  .vblocks-logo { width: 49vw; margin-top: 1.8vh; margin-bottom: 7vh; }
+  .vblocks-logo { width: 49vw; margin-top: 3vh; margin-bottom: 7vh; }
   .menu-list { gap: 1.6rem; max-width: 99vw; margin-top: 4.2vh; }
   .menu-btn { font-size: 1.04rem; min-height: 59px; padding: 0 1.1rem;}
   .info-btn { width: 33px; height: 33px; font-size: 1.07rem;}
@@ -642,7 +642,7 @@ body[data-universe="new_world_explorer"].vr-body-game #view-game .vr-choice-labe
   .vblocks-logo {
     width: min(320px, 42vw);
     max-width: 320px;
-    margin-top: 1.6vh;
+    margin-top: 3vh;
     margin-bottom: 7vh;
   }
 


### PR DESCRIPTION
### Motivation
- Ensure the `.vblocks-logo` has consistent top spacing across default, mobile and tablet/desktop breakpoints for visual alignment.

### Description
- Updated `style/main.css` to set the default `.vblocks-logo` `margin-top` to `3vh`.
- Replaced the `@media (max-width: 540px)` mobile block to use the requested values and set `.vblocks-logo` `margin-top: 3vh`.
- Updated the `@media (min-width: 768px)` rule to set `.vblocks-logo` `margin-top: 3vh` for tablet/desktop.

### Testing
- Ran `git diff --check` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1981d0268c8321aefbe0cfe377104d)