### PR TITLE
Adjust container top spacing

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -74,7 +74,7 @@ html, body {
   justify-content: flex-start;
   position: relative;
   gap: 0;
-  padding-top: calc(var(--safe-top) + 18px);
+  padding-top: calc(var(--safe-top) + 42px);
   padding-bottom: calc(var(--safe-bottom) + 16px);
   box-sizing: border-box;
 }
@@ -633,7 +633,7 @@ body[data-universe="new_world_explorer"].vr-body-game #view-game .vr-choice-labe
   }
 
   .container {
-    padding-top: 2.5vh;
+    padding-top: 5vh;
     padding-left: 18px;
     padding-right: 18px;
     box-sizing: border-box;


### PR DESCRIPTION
### Motivation
- Increase top spacing for the main `.container` to fix a layout block caused by insufficient top padding across viewports.

### Description
- In `style/main.css` updated the `.container` base `padding-top` from `calc(var(--safe-top) + 18px)` to `calc(var(--safe-top) + 42px)`.
- In the `@media (min-width: 768px)` block updated the `.container` `padding-top` from `2.5vh` to `5vh`.

### Testing
- Ran `git diff --check` which completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19868462b48321a2c3d7cb5c68a297)