### PR TITLE
Adjust revive token and top button icon sizing

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -168,7 +168,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: clamp(4px, 2.4vw, 10px);
+  gap: clamp(3px, 1.5vw, 7px);
   min-width: 0;
   padding-bottom: 6px;
   flex-shrink: 1;
@@ -188,23 +188,23 @@
 }
 
     .top-mini-action img {
-  width: clamp(21px, 7vw, 25px);
-  height: clamp(21px, 7vw, 25px);
+  width: clamp(19px, 5.8vw, 23px);
+  height: clamp(19px, 5.8vw, 23px);
   display: block;
   object-fit: contain;
 }
 
 @media (max-width: 380px) {
   .top-mini-action img {
-    width: 22px !important;
-    height: 22px !important;
+    width: 20px !important;
+    height: 20px !important;
   }
 }
 
 @media (max-width: 340px) {
   .top-mini-action img {
-    width: 20px !important;
-    height: 20px !important;
+    width: 18px !important;
+    height: 18px !important;
   }
 }
     .side-canvas-block {

--- a/concours.html
+++ b/concours.html
@@ -300,8 +300,8 @@
 }
 
 .top-mini-action img {
-  width: clamp(30px, 10vw, 36px);
-  height: clamp(30px, 10vw, 36px);
+  width: clamp(24px, 7vw, 28px);
+  height: clamp(24px, 7vw, 28px);
   display: block;
   object-fit: contain;
 }

--- a/duel.html
+++ b/duel.html
@@ -326,7 +326,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: clamp(4px, 2.4vw, 10px);
+  gap: clamp(3px, 1.5vw, 7px);
   min-width: 0;
   padding-bottom: 6px;
   flex-shrink: 1;
@@ -346,23 +346,23 @@
 }
 
 .top-mini-action img {
-  width: clamp(21px, 7vw, 25px);
-  height: clamp(21px, 7vw, 25px);
+  width: clamp(19px, 5.8vw, 23px);
+  height: clamp(19px, 5.8vw, 23px);
   display: block;
   object-fit: contain;
 }
 
 @media (max-width: 380px) {
   .top-mini-action img {
-    width: 22px !important;
-    height: 22px !important;
+    width: 20px !important;
+    height: 20px !important;
   }
 }
 
 @media (max-width: 340px) {
   .top-mini-action img {
-    width: 20px !important;
-    height: 20px !important;
+    width: 18px !important;
+    height: 18px !important;
   }
 }
 </style>

--- a/infini.html
+++ b/infini.html
@@ -307,7 +307,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: clamp(4px, 2.4vw, 10px);
+  gap: clamp(3px, 1.5vw, 7px);
   min-width: 0;
   padding-bottom: 6px;
   flex-shrink: 1;
@@ -327,23 +327,23 @@ body {
 }
 
 .top-mini-action img {
-  width: clamp(21px, 7vw, 25px);
-  height: clamp(21px, 7vw, 25px);
+  width: clamp(19px, 5.8vw, 23px);
+  height: clamp(19px, 5.8vw, 23px);
   display: block;
   object-fit: contain;
 }
 
 @media (max-width: 380px) {
   .top-mini-action img {
-    width: 22px !important;
-    height: 22px !important;
+    width: 20px !important;
+    height: 20px !important;
   }
 }
 
 @media (max-width: 340px) {
   .top-mini-action img {
-    width: 20px !important;
-    height: 20px !important;
+    width: 18px !important;
+    height: 18px !important;
   }
 }
 </style>

--- a/js/game.js
+++ b/js/game.js
@@ -1135,7 +1135,7 @@ overlay.querySelector('#resume-yes').onclick = () => {
                 <span style="display:flex;align-items:center;justify-content:center;gap:6px;font-weight:800;">
   <span>${tt('end.revive.label','Revivre')}</span>
   <span>1</span>
-  <img src="assets/images/jeton.webp" alt="" style="width:22px;height:22px;object-fit:contain;transform:translateY(4px);">
+  <img src="assets/images/jeton.webp" alt="" style="width:22px;height:22px;object-fit:contain;transform:translateY(1px);">
 </span>
               </button>
 


### PR DESCRIPTION
### Motivation
- Nudge the revive token icon up slightly so it visually aligns better inside the “Revivre 1” button. 
- Slightly reduce horizontal gap and icon sizes of the top control buttons so they no longer touch the board squares on smaller viewports. 
- Keep the concours (contest) pause icon visually consistent by reducing its size for the single-center button.

### Description
- Changed inline transform for the revive button icon from `transform:translateY(4px)` to `transform:translateY(1px)` in `js/game.js` to raise the token image. 
- Updated `.center-top-controls` gap from `gap: clamp(4px, 2.4vw, 10px)` to `gap: clamp(3px, 1.5vw, 7px)` in `classic.html`, `infini.html`, and `duel.html`. 
- Reduced `.top-mini-action img` sizing from `clamp(21px, 7vw, 25px)` to `clamp(19px, 5.8vw, 23px)` and tightened small-breakpoint media rules to `20px` (<=380px) and `18px` (<=340px) in `classic.html`, `infini.html`, and `duel.html`. 
- Reduced the central pause icon size in `concours.html` from `clamp(30px, 10vw, 36px)` to `clamp(24px, 7vw, 28px)`.

### Testing
- Verified replacements by running `rg -n` to search for the new `translateY(1px)` and updated CSS patterns across the modified files. 
- Inspected the modified snippets with line-numbered output (`nl`) to confirm the intended lines were updated. 
- Ensured each targeted pattern had exactly one occurrence replaced in each file using a script-based check (counts matched expected results).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a198ef2017c83219dfcdee42055b770)