### PR TITLE
Adjust mini top controls on narrow screens

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -195,6 +195,19 @@
 }
 
 @media (max-width: 380px) {
+  .center-top-controls {
+    gap: 3px !important;
+  }
+
+  .top-mini-action {
+    padding: 0 !important;
+    width: 22px !important;
+    height: 22px !important;
+    min-width: 22px !important;
+    max-width: 22px !important;
+    flex: 0 0 22px !important;
+  }
+
   .top-mini-action img {
     width: 20px !important;
     height: 20px !important;
@@ -202,9 +215,22 @@
 }
 
 @media (max-width: 340px) {
-  .top-mini-action img {
+  .center-top-controls {
+    gap: 1px !important;
+  }
+
+  .top-mini-action {
+    padding: 0 !important;
     width: 18px !important;
     height: 18px !important;
+    min-width: 18px !important;
+    max-width: 18px !important;
+    flex: 0 0 18px !important;
+  }
+
+  .top-mini-action img {
+    width: 16px !important;
+    height: 16px !important;
   }
 }
     .side-canvas-block {

--- a/duel.html
+++ b/duel.html
@@ -353,6 +353,19 @@
 }
 
 @media (max-width: 380px) {
+  .center-top-controls {
+    gap: 3px !important;
+  }
+
+  .top-mini-action {
+    padding: 0 !important;
+    width: 22px !important;
+    height: 22px !important;
+    min-width: 22px !important;
+    max-width: 22px !important;
+    flex: 0 0 22px !important;
+  }
+
   .top-mini-action img {
     width: 20px !important;
     height: 20px !important;
@@ -360,9 +373,22 @@
 }
 
 @media (max-width: 340px) {
-  .top-mini-action img {
+  .center-top-controls {
+    gap: 1px !important;
+  }
+
+  .top-mini-action {
+    padding: 0 !important;
     width: 18px !important;
     height: 18px !important;
+    min-width: 18px !important;
+    max-width: 18px !important;
+    flex: 0 0 18px !important;
+  }
+
+  .top-mini-action img {
+    width: 16px !important;
+    height: 16px !important;
   }
 }
 </style>

--- a/infini.html
+++ b/infini.html
@@ -334,6 +334,19 @@ body {
 }
 
 @media (max-width: 380px) {
+  .center-top-controls {
+    gap: 3px !important;
+  }
+
+  .top-mini-action {
+    padding: 0 !important;
+    width: 22px !important;
+    height: 22px !important;
+    min-width: 22px !important;
+    max-width: 22px !important;
+    flex: 0 0 22px !important;
+  }
+
   .top-mini-action img {
     width: 20px !important;
     height: 20px !important;
@@ -341,9 +354,22 @@ body {
 }
 
 @media (max-width: 340px) {
-  .top-mini-action img {
+  .center-top-controls {
+    gap: 1px !important;
+  }
+
+  .top-mini-action {
+    padding: 0 !important;
     width: 18px !important;
     height: 18px !important;
+    min-width: 18px !important;
+    max-width: 18px !important;
+    flex: 0 0 18px !important;
+  }
+
+  .top-mini-action img {
+    width: 16px !important;
+    height: 16px !important;
   }
 }
 </style>


### PR DESCRIPTION
### Motivation

- Remplacer des règles CSS mobiles minimalistes qui limitaient uniquement la taille des images par des règles complètes pour assurer un espacement et des dimensions cohérents des contrôles en haut sur petits écrans.

### Description

- Remplacé les blocs `@media (max-width: 380px)` / `@media (max-width: 340px)` dans `classic.html`, `infini.html` et `duel.html` par de nouveaux blocs étendant les styles.
- Ajouté des réglages de `gap` pour `.center-top-controls` aux deux breakpoints afin de réduire l'espace entre les contrôles.
- Contraint les boutons `.top-mini-action` avec `padding`, `width`, `height`, `min-width`, `max-width` et `flex: 0 0 <size>` pour forcer des dimensions fixes selon le breakpoint.
- Ajusté les dimensions des images `.top-mini-action img` à `20/16px` (et `20/18px` selon breakpoint) pour correspondre aux nouvelles tailles de boutons.

### Testing

- Recherches automatisées avec `rg` pour vérifier l'apparition des nouvelles règles ont réussi (`rg -n "center-top-controls \\{|flex: 0 0 22px|flex: 0 0 18px|width: 16px !important" classic.html infini.html duel.html`).
- Vérification de l'arbre Git pour erreurs de diff avec `git diff --check` a réussi (aucun problème signalé).
- Les fichiers modifiés sont `classic.html`, `infini.html` et `duel.html` et le changement a été commité.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199395aea88321912e20de94c94bb8)