### PR TITLE
Restore mini action responsive icon sizes

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -195,42 +195,16 @@
 }
 
 @media (max-width: 380px) {
-  .center-top-controls {
-    gap: 3px !important;
-  }
-
-  .top-mini-action {
-    padding: 0 !important;
+  .top-mini-action img {
     width: 22px !important;
     height: 22px !important;
-    min-width: 22px !important;
-    max-width: 22px !important;
-    flex: 0 0 22px !important;
-  }
-
-  .top-mini-action img {
-    width: 20px !important;
-    height: 20px !important;
   }
 }
 
 @media (max-width: 340px) {
-  .center-top-controls {
-    gap: 1px !important;
-  }
-
-  .top-mini-action {
-    padding: 0 !important;
-    width: 18px !important;
-    height: 18px !important;
-    min-width: 18px !important;
-    max-width: 18px !important;
-    flex: 0 0 18px !important;
-  }
-
   .top-mini-action img {
-    width: 16px !important;
-    height: 16px !important;
+    width: 19px !important;
+    height: 19px !important;
   }
 }
     .side-canvas-block {

--- a/duel.html
+++ b/duel.html
@@ -353,42 +353,16 @@
 }
 
 @media (max-width: 380px) {
-  .center-top-controls {
-    gap: 3px !important;
-  }
-
-  .top-mini-action {
-    padding: 0 !important;
+  .top-mini-action img {
     width: 22px !important;
     height: 22px !important;
-    min-width: 22px !important;
-    max-width: 22px !important;
-    flex: 0 0 22px !important;
-  }
-
-  .top-mini-action img {
-    width: 20px !important;
-    height: 20px !important;
   }
 }
 
 @media (max-width: 340px) {
-  .center-top-controls {
-    gap: 1px !important;
-  }
-
-  .top-mini-action {
-    padding: 0 !important;
-    width: 18px !important;
-    height: 18px !important;
-    min-width: 18px !important;
-    max-width: 18px !important;
-    flex: 0 0 18px !important;
-  }
-
   .top-mini-action img {
-    width: 16px !important;
-    height: 16px !important;
+    width: 19px !important;
+    height: 19px !important;
   }
 }
 </style>

--- a/infini.html
+++ b/infini.html
@@ -334,42 +334,16 @@ body {
 }
 
 @media (max-width: 380px) {
-  .center-top-controls {
-    gap: 3px !important;
-  }
-
-  .top-mini-action {
-    padding: 0 !important;
+  .top-mini-action img {
     width: 22px !important;
     height: 22px !important;
-    min-width: 22px !important;
-    max-width: 22px !important;
-    flex: 0 0 22px !important;
-  }
-
-  .top-mini-action img {
-    width: 20px !important;
-    height: 20px !important;
   }
 }
 
 @media (max-width: 340px) {
-  .center-top-controls {
-    gap: 1px !important;
-  }
-
-  .top-mini-action {
-    padding: 0 !important;
-    width: 18px !important;
-    height: 18px !important;
-    min-width: 18px !important;
-    max-width: 18px !important;
-    flex: 0 0 18px !important;
-  }
-
   .top-mini-action img {
-    width: 16px !important;
-    height: 16px !important;
+    width: 19px !important;
+    height: 19px !important;
   }
 }
 </style>


### PR DESCRIPTION
### Motivation
- Revert the responsive CSS for the top mini-action controls to a simpler, focused rule that only targets the icon images, restoring prior behavior. 
- Apply a tiny visual correction to the smallest breakpoint so icons are slightly smaller at `max-width: 340px`.

### Description
- Replaced the previous multi-property media blocks with succinct image-only media rules in `classic.html`, `duel.html`, and `infini.html`.
- Set icon sizes to `22px` at `@media (max-width: 380px)` and to `19px` at `@media (max-width: 340px)` for `.top-mini-action img` across the three pages. 
- Removed the previous adjustments to `.top-mini-action` sizing and `.center-top-controls` gaps so the media queries now only affect icon dimensions.

### Testing
- Ran `git diff --check` which produced no issues and completed successfully. 
- Verified the changes are present using `rg -n "@media (max-width: 380px)|@media (max-width: 340px)|width: 22px !important;|width: 19px !important;" classic.html duel.html infini.html` which returned the updated locations. 
- Commit succeeded with message `Restore mini action responsive icon sizes` (commit `b796faa`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199823b4388321afa3235ae0daaa71)