### PR TITLE
Réduire les tailles responsive des icônes `.top-mini-action` (classic / infini / duel)

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -196,15 +196,15 @@
 
 @media (max-width: 380px) {
   .top-mini-action img {
-    width: 22px !important;
-    height: 22px !important;
+    width: 20px !important;
+    height: 20px !important;
   }
 }
 
 @media (max-width: 340px) {
   .top-mini-action img {
-    width: 19px !important;
-    height: 19px !important;
+    width: 18px !important;
+    height: 18px !important;
   }
 }
     .side-canvas-block {

--- a/duel.html
+++ b/duel.html
@@ -354,15 +354,15 @@
 
 @media (max-width: 380px) {
   .top-mini-action img {
-    width: 22px !important;
-    height: 22px !important;
+    width: 20px !important;
+    height: 20px !important;
   }
 }
 
 @media (max-width: 340px) {
   .top-mini-action img {
-    width: 19px !important;
-    height: 19px !important;
+    width: 18px !important;
+    height: 18px !important;
   }
 }
 </style>

--- a/infini.html
+++ b/infini.html
@@ -335,15 +335,15 @@ body {
 
 @media (max-width: 380px) {
   .top-mini-action img {
-    width: 22px !important;
-    height: 22px !important;
+    width: 20px !important;
+    height: 20px !important;
   }
 }
 
 @media (max-width: 340px) {
   .top-mini-action img {
-    width: 19px !important;
-    height: 19px !important;
+    width: 18px !important;
+    height: 18px !important;
   }
 }
 </style>


### PR DESCRIPTION
### Motivation
- Uniformiser l'apparence des mini-icônes en haut de l'interface sur petits écrans pour garder un espacement propre et éviter des icônes trop grandes.
- Conserver la taille plus grande prévue pour le bouton pause central de `concours.html` qui n'a pas le même risque d'encombrement.

### Description
- Dans `classic.html`, `infini.html` et `duel.html` les overrides responsive ont été ajustés à `width: 20px !important; height: 20px !important;` pour `@media (max-width: 380px)` et à `width: 18px !important; height: 18px !important;` pour `@media (max-width: 340px)`.
- Les règles principales `.top-mini-action img { width: clamp(...); height: clamp(...); }` et `.center-top-controls` ont été conservées lorsqu'elles correspondaient déjà aux valeurs demandées.
- `concours.html` a été vérifiée et utilise déjà la taille prévue pour le bouton pause (`clamp(24px, 7vw, 28px)`), donc aucune modification n'a été apportée.

### Testing
- Recherches par motifs avec `rg` ont confirmé la présence et la mise à jour des blocs ciblés dans les trois fichiers modifiés et l'absence de modification nécessaire dans `concours.html`.
- Validation via `git diff --check` n'a retourné aucune erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1999a222948321bdec83c5663bbb8d)