### PR TITLE
Route score helpers via window.userData and improve secure highscore query

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -3220,32 +3220,37 @@ if (score > highscoreCloud) {
     };
   }
 
-  // === SUPABASE helpers déjà présents ailleurs dans ton app ===
+  // === SUPABASE helpers VBlocks ===
   async function getHighScoreSupabase() {
     try {
-      if (typeof window.secureGetMe === 'function') {
-        const me = await window.secureGetMe();
-        return Number(me?.high_score ?? 0);
+      if (window.userData && typeof window.userData.getHighScore === 'function') {
+        return Number(await window.userData.getHighScore()) || 0;
       }
-    } catch (_) {}
+    } catch (e) {
+      console.warn('[VBlocks] getHighScoreSupabase failed:', e);
+    }
     return 0;
   }
 
   async function setHighScoreSupabase(value) {
     try {
-      if (typeof window.secureSetHighScore === 'function') {
-        return await window.secureSetHighScore(value);
+      if (window.userData && typeof window.userData.setHighScore === 'function') {
+        return await window.userData.setHighScore(value);
       }
-    } catch (_) {}
+    } catch (e) {
+      console.warn('[VBlocks] setHighScoreSupabase failed:', e);
+    }
     return null;
   }
 
   async function setLastScoreSupabase(value) {
     try {
-      if (typeof window.secureSetLastScore === 'function') {
-        return await window.secureSetLastScore(value);
+      if (window.userData && typeof window.userData.setLastScore === 'function') {
+        return await window.userData.setLastScore(value);
       }
-    } catch (_) {}
+    } catch (e) {
+      console.warn('[VBlocks] setLastScoreSupabase failed:', e);
+    }
     return null;
   }
 

--- a/js/userData.js
+++ b/js/userData.js
@@ -687,8 +687,23 @@ async function setHighScoreSecure(score) {
   if (error) throw error;
 }
 async function getHighScoreSecure() {
-  const p = await getProfileSecure();
-  return p?.highscore || 0;
+  await bootstrapAuthAndProfile();
+
+  const uid = await getAuthUserId();
+  if (!uid) return 0;
+
+  const { data, error } = await sb
+    .from('vblocks_users')
+    .select('highscore')
+    .or(`id.eq.${uid},auth_id.eq.${uid}`)
+    .maybeSingle();
+
+  if (error) {
+    console.warn('[VBlocks] getHighScoreSecure failed:', error);
+    return 0;
+  }
+
+  return Number(data?.highscore || 0);
 }
 async function setLastScoreSecure(score) {
   await bootstrapAuthAndProfile();


### PR DESCRIPTION
### Motivation
- Unify game score operations to use the application's `window.userData` API instead of ad-hoc `secure*` globals so the game integrates with VBlocks user layer. 
- Make secure high-score retrieval more robust by ensuring auth/profile bootstrap and querying the `vblocks_users` table directly.

### Description
- Replace `getHighScoreSupabase`, `setHighScoreSupabase`, and `setLastScoreSupabase` in `js/game.js` to call `window.userData.getHighScore`, `window.userData.setHighScore`, and `window.userData.setLastScore` respectively, and add `console.warn` logging on failures. 
- Update `getHighScoreSecure()` in `js/userData.js` to call `bootstrapAuthAndProfile()`, obtain `getAuthUserId()`, and query `sb.from('vblocks_users').select('highscore').or(...)` with `.maybeSingle()`, returning a numeric value and logging errors. 
- Modified files: `js/game.js` and `js/userData.js`.

### Testing
- Ran `node --check js/game.js && node --check js/userData.js` and both files passed the syntax check. 
- Ran `git diff --check` which reported no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21b0eed8ec83219e8137bc427619e3)