### PR TITLE
Allow hard drop to compute landing regardless of ghost visibility

### DIFF
--- a/js/concours.js
+++ b/js/concours.js
@@ -1697,8 +1697,8 @@ function fillRectThemeSafe(c, px, py, size) {
       safeRedraw();
     }
 
-    function getGhostPiece() {
-      if (!ghostPieceEnabled) return null;
+    function getGhostPiece(ignoreVisibility = false) {
+      if (!ignoreVisibility && !ghostPieceEnabled) return null;
       if (!currentPiece || !currentPiece.shape) return null;
       let ghost = JSON.parse(JSON.stringify(currentPiece));
       while (!collision(ghost)) { ghost.y++; }
@@ -1709,7 +1709,7 @@ function fillRectThemeSafe(c, px, py, size) {
     // === HARD DROP
     function hardDrop() {
       if (!currentPiece) return;
-      const ghost = getGhostPiece();
+      const ghost = getGhostPiece(true);
       if (!ghost) return;
       currentPiece.y = ghost.y;
       stopSoftDrop();

--- a/js/game_duel.js
+++ b/js/game_duel.js
@@ -1003,8 +1003,15 @@ function showEndPopup(points) {
       safeRedraw();
     }
 
-    function getGhostPiece() {
-      if (!ghostPieceEnabled || !currentPiece || !currentPiece.shape) return null;
+    function getGhostPiece(ignoreVisibility = false) {
+      if (
+        (!ignoreVisibility && !ghostPieceEnabled) ||
+        !currentPiece ||
+        !currentPiece.shape
+      ) {
+        return null;
+      }
+
       const ghost = JSON.parse(JSON.stringify(currentPiece));
       while (!collision(ghost)) { ghost.y++; }
       ghost.y--;
@@ -1013,7 +1020,7 @@ function showEndPopup(points) {
 
     function hardDrop() {
       if (!currentPiece) return;
-      const ghost = getGhostPiece();
+      const ghost = getGhostPiece(true);
       if (!ghost) return;
       currentPiece.y = ghost.y;
       stopSoftDrop();


### PR DESCRIPTION
### Motivation
- Hard drop should compute the piece landing position even when the ghost-piece display is disabled, to ensure deterministic behavior for drops.
- Introduce a way to ignore the ghost visibility flag in the ghost lookup while preserving the default visibility behavior for rendering.

### Description
- Add an optional `ignoreVisibility` parameter to `getGhostPiece` in `js/concours.js` and `js/game_duel.js` and update the visibility check to respect this flag by default (preserving previous behavior when the parameter is omitted). 
- Update the `hardDrop` function in both files to call `getGhostPiece(true)` so the landing position is computed even if `ghostPieceEnabled` is false. 
- Keep all other `hardDrop` behavior unchanged and maintain existing collision logic used to derive the ghost position.

### Testing
- Ran `node --check js/concours.js`, which completed successfully. 
- Ran `node --check js/game_duel.js`, which completed successfully. 
- Ran `git diff --check` to verify no whitespace or diff errors, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a96df80808321b383e3c8ed257654)